### PR TITLE
Surface open questions from plan in issue comment

### DIFF
--- a/orchestrator/src/main/java/dev/smithyai/orchestrator/service/claude/dto/PlanResult.java
+++ b/orchestrator/src/main/java/dev/smithyai/orchestrator/service/claude/dto/PlanResult.java
@@ -1,0 +1,13 @@
+package dev.smithyai.orchestrator.service.claude.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PlanResult(List<String> openQuestions) {
+    public PlanResult {
+        if (openQuestions == null) {
+            openQuestions = List.of();
+        }
+    }
+}

--- a/orchestrator/src/main/java/dev/smithyai/orchestrator/workflow/flows/smithy/SmithyWorkflowInstance.java
+++ b/orchestrator/src/main/java/dev/smithyai/orchestrator/workflow/flows/smithy/SmithyWorkflowInstance.java
@@ -7,6 +7,7 @@ import dev.smithyai.orchestrator.model.*;
 import dev.smithyai.orchestrator.model.events.WorkflowEvent;
 import dev.smithyai.orchestrator.service.claude.ClaudeSession;
 import dev.smithyai.orchestrator.service.claude.PromptRenderer;
+import dev.smithyai.orchestrator.service.claude.dto.PlanResult;
 import dev.smithyai.orchestrator.service.docker.*;
 import dev.smithyai.orchestrator.service.docker.dto.ContainerConfig;
 import dev.smithyai.orchestrator.service.docker.dto.ContainerState;
@@ -217,19 +218,39 @@ public class SmithyWorkflowInstance extends AbstractWorkflowInstance {
                 throw new RuntimeException("Failed to copy plan file: " + copyResult.stderr());
             }
 
+            // Extract open questions from the plan
+            List<String> openQuestions = List.of();
+            try {
+                String extractPrompt = renderer.render(
+                    "refinement_extract.md.j2",
+                    Map.of("plan_file_path", planPath)
+                );
+                PlanResult planResult = claude.send(extractPrompt, PlanResult.class);
+                openQuestions = planResult.openQuestions();
+            } catch (Exception ex) {
+                log.warn("Failed to extract open questions for issue #{}", ctx.number(), ex);
+            }
+
             var pushResult = session.exec("smithy-commit-and-push", "Development plan for #" + ctx.number());
             if (pushResult.exitCode() != 0) {
                 throw new RuntimeException("Failed to commit and push plan: " + pushResult.stderr());
             }
 
-            // Post link to plan
+            // Post link to plan with open questions if any
             String publicBase = e.repoHtmlUrl();
             String planUrl = vcsClient.fileBrowseUrl(publicBase, branch, planPath);
+            var comment = new StringBuilder("Development plan: [%s](%s)".formatted(planPath, planUrl));
+            if (!openQuestions.isEmpty()) {
+                comment.append("\n\n### Open Questions");
+                for (String q : openQuestions) {
+                    comment.append("\n- ").append(q);
+                }
+            }
             issueTracker.createIssueComment(
                 info.owner(),
                 info.repo(),
                 ctx.number(),
-                "Development plan: [%s](%s)".formatted(planPath, planUrl)
+                comment.toString()
             );
 
             log.info("Refinement complete for issue #{}", ctx.number());

--- a/orchestrator/src/main/resources/prompts/refinement.md.j2
+++ b/orchestrator/src/main/resources/prompts/refinement.md.j2
@@ -18,4 +18,4 @@ You may read these files directly or copy them into the repository if needed.
 
 ## Instructions
 
-Explore the codebase and create a plan for this issue. If functional input or decisions are required, list that as a section at the end of the plan.
+Explore the codebase and create a plan for this issue. If there are genuine ambiguities or decisions that require human input before implementation can proceed, list them as short questions in an "Open Questions" section at the end of the plan. Only include questions where the answer materially affects the implementation — do not generate questions for the sake of it. If the issue is clear enough to implement without further input, do not include an Open Questions section.

--- a/orchestrator/src/main/resources/prompts/refinement_extract.md.j2
+++ b/orchestrator/src/main/resources/prompts/refinement_extract.md.j2
@@ -1,0 +1,3 @@
+Read the plan file at `{{ plan_file_path }}` and extract any open questions from it.
+
+Only include questions where the answer materially affects the implementation. Each question should be a single concise sentence. If there are no genuine open questions, return an empty list.


### PR DESCRIPTION
After plan generation, resume the Claude session with a structured output call to extract open questions. If any exist, they are appended to the issue comment so users can answer without clicking through to the plan file. Fixes #9 