### PR TITLE
feat: tag issue author and allow comment-based plan approval

### DIFF
--- a/examples/github-local/docker-compose.yml
+++ b/examples/github-local/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - ARCHITECT_BOT_USER=${ARCHITECT_BOT_USER:-architect-bot}
       - SMITHY_BOT_EMAIL=${SMITHY_BOT_EMAIL:-}
       - ARCHITECT_BOT_EMAIL=${ARCHITECT_BOT_EMAIL:-}
+      - DOCKER_API_VERSION=1.41
     networks:
       - smithy-net
 

--- a/orchestrator/src/main/java/dev/smithyai/orchestrator/model/IssueContext.java
+++ b/orchestrator/src/main/java/dev/smithyai/orchestrator/model/IssueContext.java
@@ -1,3 +1,3 @@
 package dev.smithyai.orchestrator.model;
 
-public record IssueContext(RepoInfo info, int number, String title, String body, String baseBranch) {}
+public record IssueContext(RepoInfo info, int number, String title, String body, String baseBranch, String author) {}

--- a/orchestrator/src/main/java/dev/smithyai/orchestrator/web/EventMapper.java
+++ b/orchestrator/src/main/java/dev/smithyai/orchestrator/web/EventMapper.java
@@ -337,7 +337,8 @@ public class EventMapper {
         String title = issue.get("title").asText();
         String body = issue.path("body").asText("");
         String baseBranch = Naming.resolveBaseBranch(issue.path("ref").asText(""));
-        return new IssueContext(info, number, title, body, baseBranch);
+        String author = issue.path("user").path("login").asText("");
+        return new IssueContext(info, number, title, body, baseBranch, author);
     }
 
     private PrContext extractPr(RepoInfo info, JsonNode pr) {

--- a/orchestrator/src/main/java/dev/smithyai/orchestrator/web/GitHubEventMapper.java
+++ b/orchestrator/src/main/java/dev/smithyai/orchestrator/web/GitHubEventMapper.java
@@ -101,7 +101,16 @@ public class GitHubEventMapper {
 
         var ctx = extractIssue(payload);
         String commentBody = payload.path("comment").path("body").asText("");
+        if (isUserAssigned(payload, botUser) && isPlanApproval(commentBody)) {
+            return new WorkflowEvent.PlanApproved(ctx, commentUser);
+        }
         return new WorkflowEvent.IssueComment(ctx, commentBody);
+    }
+
+    private static boolean isPlanApproval(String body) {
+        String lower = body.strip().toLowerCase();
+        return lower.equals("approved") || lower.equals("/approve") || lower.equals("lgtm")
+            || lower.equals("looks good") || lower.equals("go ahead");
     }
 
     private WorkflowEvent mapPrConversationFromIssueComment(JsonNode payload, String commentUser) {
@@ -345,7 +354,8 @@ public class GitHubEventMapper {
         String title = issue.path("title").asText("");
         String body = issue.path("body").asText("");
         String baseBranch = Naming.resolveBaseBranch(issue.path("ref").asText(""));
-        return new IssueContext(info, number, title, body, baseBranch);
+        String author = issue.path("user").path("login").asText("");
+        return new IssueContext(info, number, title, body, baseBranch, author);
     }
 
     private PrContext extractPr(RepoInfo info, JsonNode pr) {

--- a/orchestrator/src/main/java/dev/smithyai/orchestrator/web/GitLabEventMapper.java
+++ b/orchestrator/src/main/java/dev/smithyai/orchestrator/web/GitLabEventMapper.java
@@ -397,7 +397,8 @@ public class GitLabEventMapper {
         String body = attrs.path("description").asText("");
         // GitLab doesn't have a direct "ref" field on issues — default to main
         String baseBranch = Naming.resolveBaseBranch("");
-        return new IssueContext(info, number, title, body, baseBranch);
+        String author = attrs.path("author_id").asText("");
+        return new IssueContext(info, number, title, body, baseBranch, author);
     }
 
     private PrContext extractPrFromMr(RepoInfo info, JsonNode mr) {

--- a/orchestrator/src/main/java/dev/smithyai/orchestrator/workflow/flows/smithy/SmithyWorkflowInstance.java
+++ b/orchestrator/src/main/java/dev/smithyai/orchestrator/workflow/flows/smithy/SmithyWorkflowInstance.java
@@ -251,11 +251,19 @@ public class SmithyWorkflowInstance extends AbstractWorkflowInstance {
             String publicBase = e.repoHtmlUrl();
             String planUrl = vcsClient.fileBrowseUrl(publicBase, branch, planPath);
             var comment = new StringBuilder("Development plan: [%s](%s)".formatted(planPath, planUrl));
+            String authorMention = (ctx.author() != null && !ctx.author().isBlank())
+                ? "@" + ctx.author() + " "
+                : "";
             if (!openQuestions.isEmpty()) {
                 comment.append("\n\n### Open Questions");
                 for (String q : openQuestions) {
                     comment.append("\n- ").append(q);
                 }
+                comment.append("\n\n").append(authorMention)
+                    .append("Please clarify the above questions, then reply with `approved` or `/approve` to start implementation.");
+            } else {
+                comment.append("\n\n").append(authorMention)
+                    .append("The plan is ready. Reply with `approved` or `/approve` to start implementation.");
             }
             issueTracker.createIssueComment(
                 info.owner(),


### PR DESCRIPTION
## Summary
- `IssueContext` gains an `author` field populated from the issue payload (GitHub, GitLab, Forgejo)
- Smithy now tags `@author` in every refinement comment and explicitly asks for approval
- Approval via comment: replying `approved`, `/approve`, `lgtm`, `looks good`, or `go ahead` triggers `PlanApproved` — no label required
- `DOCKER_API_VERSION=1.41` pinned in `github-local` compose to fix mismatch with older Docker daemons

## Depends on
PR #1 (GitHub integration) — modifies `GitHubEventMapper` introduced there.

## Test plan
- [ ] Assign issue → refinement comment tags `@<author>` with approval instructions
- [ ] Comment `approved` → Smithy moves to BUILD state
- [ ] Comment `lgtm` → same result

🤖 Generated with [Claude Code](https://claude.com/claude-code)