### PR TITLE
feat(knowledgebase): configurable LLM provider (Ollama or OpenAI)

### DIFF
--- a/examples/full/docker-compose.yml
+++ b/examples/full/docker-compose.yml
@@ -36,6 +36,17 @@ services:
     networks:
       - smithy-net
 
+  ollama:
+    image: ollama/ollama:latest
+    restart: unless-stopped
+    profiles:
+      - knowledgebase
+    volumes:
+      - ollama-models:/root/.ollama
+    networks:
+      - smithy-net
+    entrypoint: ["/bin/sh", "-c", "ollama serve & pid=$$!; sleep 5; ollama pull ${EMBEDDING_MODEL:-nomic-embed-text}; ollama pull ${CHAT_MODEL:-llama3.2}; wait $$pid"]
+
   knowledgebase:
     image: ghcr.io/smithy-ai/knowledgebase:${IMAGE_TAG:-dev}
     restart: unless-stopped
@@ -43,8 +54,14 @@ services:
       - knowledgebase
     ports:
       - "8000:8000"
+    depends_on:
+      - ollama
     environment:
+      - AI_PROVIDER=${AI_PROVIDER:-ollama}
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://ollama:11434}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - EMBEDDING_MODEL=${EMBEDDING_MODEL:-}
+      - CHAT_MODEL=${CHAT_MODEL:-}
       - VCS_URL=${KB_VCS_URL:-}
       - VCS_TOKEN=${KB_VCS_TOKEN:-}
       - WEBHOOK_SECRET=${KB_WEBHOOK_SECRET:-}
@@ -69,6 +86,7 @@ services:
 
 volumes:
   kb-vectorstore:
+  ollama-models:
   caddy-data:
   caddy-config:
 

--- a/knowledgebase/build.gradle.kts
+++ b/knowledgebase/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.ai:spring-ai-starter-model-openai")
+    implementation("org.springframework.ai:spring-ai-starter-model-ollama")
     implementation("org.springframework.ai:spring-ai-starter-mcp-server-webmvc")
     implementation("org.springframework.ai:spring-ai-vector-store")
     implementation("com.fasterxml.jackson.core:jackson-databind")

--- a/knowledgebase/src/main/java/dev/smithyai/knowledgebase/config/ConfigLoader.java
+++ b/knowledgebase/src/main/java/dev/smithyai/knowledgebase/config/ConfigLoader.java
@@ -53,6 +53,11 @@ public class ConfigLoader {
     }
 
     @Bean
+    public KnowledgebaseConfig.OllamaConfig ollamaConfig() {
+        return config.ollama();
+    }
+
+    @Bean
     public KnowledgebaseConfig.OpenaiConfig openaiConfig() {
         return config.openai();
     }

--- a/knowledgebase/src/main/java/dev/smithyai/knowledgebase/config/KnowledgebaseConfig.java
+++ b/knowledgebase/src/main/java/dev/smithyai/knowledgebase/config/KnowledgebaseConfig.java
@@ -8,6 +8,8 @@ public record KnowledgebaseConfig(
     VectorstoreConfig vectorstore,
     int chunkSize,
     WebhookConfig webhook,
+    String aiProvider,
+    OllamaConfig ollama,
     OpenaiConfig openai,
     List<RepositoryConfig> repositories
 ) {
@@ -23,7 +25,13 @@ public record KnowledgebaseConfig(
         }
     }
 
+    public record OllamaConfig(String baseUrl, String embeddingModel, String chatModel) {}
+
     public record OpenaiConfig(String apiKey, String embeddingModel, String chatModel) {}
+
+    public boolean isOllama() {
+        return !"openai".equalsIgnoreCase(aiProvider);
+    }
 
     public record RepositoryConfig(String name, String cloneUrl, String branch) {
         /** Filesystem/collection-safe key: "owner/repo" → "owner--repo" */

--- a/knowledgebase/src/main/resources/application-ollama.yml
+++ b/knowledgebase/src/main/resources/application-ollama.yml
@@ -1,0 +1,17 @@
+spring:
+  ai:
+    openai:
+      api-key: dummy-disabled
+      chat:
+        enabled: false
+      embedding:
+        enabled: false
+    ollama:
+      base-url: ${OLLAMA_BASE_URL:http://ollama:11434}
+      embedding:
+        options:
+          model: ${EMBEDDING_MODEL:nomic-embed-text}
+      chat:
+        options:
+          model: ${CHAT_MODEL:llama3.2}
+          temperature: 1

--- a/knowledgebase/src/main/resources/application-openai.yml
+++ b/knowledgebase/src/main/resources/application-openai.yml
@@ -1,0 +1,16 @@
+spring:
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      embedding:
+        options:
+          model: ${EMBEDDING_MODEL:text-embedding-3-small}
+      chat:
+        options:
+          model: ${CHAT_MODEL:gpt-4o}
+          temperature: 1
+    ollama:
+      embedding:
+        enabled: false
+      chat:
+        enabled: false

--- a/knowledgebase/src/main/resources/application.yml
+++ b/knowledgebase/src/main/resources/application.yml
@@ -1,16 +1,9 @@
 spring:
   application:
     name: knowledgebase-mcp
+  profiles:
+    active: ${AI_PROVIDER:ollama}
   ai:
-    openai:
-      api-key: ${OPENAI_API_KEY}
-      embedding:
-        options:
-          model: ${EMBEDDING_MODEL:text-embedding-3-small}
-      chat:
-        options:
-          model: ${CHAT_MODEL:gpt-4o}
-          temperature: 1
     mcp:
       server:
         enabled: true

--- a/knowledgebase/src/main/resources/knowledgebase.yml
+++ b/knowledgebase/src/main/resources/knowledgebase.yml
@@ -13,6 +13,13 @@ chunk-size: ${CHUNK_SIZE:1000}
 webhook:
   secret: ${WEBHOOK_SECRET:}
 
+ai-provider: ${AI_PROVIDER:ollama}
+
+ollama:
+  base-url: ${OLLAMA_BASE_URL:http://ollama:11434}
+  embedding-model: ${EMBEDDING_MODEL:nomic-embed-text}
+  chat-model: ${CHAT_MODEL:llama3.2}
+
 openai:
   api-key: ${OPENAI_API_KEY:}
   embedding-model: ${EMBEDDING_MODEL:text-embedding-3-small}


### PR DESCRIPTION
## Summary
Adds an `AI_PROVIDER` env var (default: `ollama`) so the knowledgebase can run with either Ollama (no API key) or OpenAI, without rebuilding the image.

- Both `spring-ai-starter-model-openai` and `spring-ai-starter-model-ollama` on the classpath
- Spring Boot profiles (`ollama` / `openai`) activated by `AI_PROVIDER` — each profile configures only its provider and disables the other
- `knowledgebase.yml` now has both `ollama:` and `openai:` sections; `KnowledgebaseConfig` exposes both
- `docker-compose` (full): adds Ollama sidecar service, passes `AI_PROVIDER` + both credential sets

## Usage
```
# Ollama (default, no API key needed)
AI_PROVIDER=ollama

# OpenAI
AI_PROVIDER=openai
OPENAI_API_KEY=sk-...
```

## Test plan
- [ ] Start with `AI_PROVIDER=ollama` — knowledgebase indexes via `nomic-embed-text`
- [ ] Start with `AI_PROVIDER=openai` + valid key — knowledgebase indexes via `text-embedding-3-small`
- [ ] Starting with `AI_PROVIDER=openai` but no key — Spring fails fast with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)