### PR TITLE
feat: trigger workflow from issue comment mention

### DIFF
--- a/orchestrator/src/main/java/dev/smithyai/orchestrator/web/GitHubEventMapper.java
+++ b/orchestrator/src/main/java/dev/smithyai/orchestrator/web/GitHubEventMapper.java
@@ -101,10 +101,23 @@ public class GitHubEventMapper {
 
         var ctx = extractIssue(payload);
         String commentBody = payload.path("comment").path("body").asText("");
+
+        if (!isUserAssigned(payload, botUser) && isBotMention(commentBody, botUser)) {
+            String repoHtmlUrl = payload.path("repository").path("html_url").asText("");
+            log.info("Bot mention detected in issue #{} comment by {} — starting workflow", ctx.number(), commentUser);
+            return new WorkflowEvent.IssueAssigned(ctx, repoHtmlUrl);
+        }
         if (isUserAssigned(payload, botUser) && isPlanApproval(commentBody)) {
             return new WorkflowEvent.PlanApproved(ctx, commentUser);
         }
         return new WorkflowEvent.IssueComment(ctx, commentBody);
+    }
+
+    private static boolean isBotMention(String body, String botUser) {
+        String lower = body.toLowerCase();
+        return lower.contains("@" + botUser.toLowerCase())
+            || lower.startsWith("/smithy")
+            || lower.startsWith("/assign");
     }
 
     private static boolean isPlanApproval(String body) {

--- a/orchestrator/src/main/java/dev/smithyai/orchestrator/workflow/flows/smithy/SmithyWorkflowInstance.java
+++ b/orchestrator/src/main/java/dev/smithyai/orchestrator/workflow/flows/smithy/SmithyWorkflowInstance.java
@@ -126,6 +126,7 @@ public class SmithyWorkflowInstance extends AbstractWorkflowInstance {
                 .on(WorkflowEvent.PlanApproved.class, this::handlePlanApproved).then(Stage.BUILD)
                 .done()
             .in(Stage.BUILD)
+                .on(WorkflowEvent.IssueComment.class, this::handleIssueCommentInBuild).thenRemain()
                 .on(WorkflowEvent.PrConversationComment.class, this::handlePrConversationComment).thenRemain()
                 .on(WorkflowEvent.PrReviewComment.class, this::handlePrReviewComment).thenRemain()
                 .on(WorkflowEvent.ReviewSubmitted.class, this::handleReviewSubmitted).thenRemain()
@@ -322,10 +323,39 @@ public class SmithyWorkflowInstance extends AbstractWorkflowInstance {
             claude.send(prompt);
             syncSessionId();
 
+            // Extract updated open questions and post a reply comment
+            String planPath = Naming.planFilePath(ctx.number());
+            List<String> openQuestions = List.of();
+            try {
+                String extractPrompt = renderer.render("refinement_extract.md.j2", Map.of("plan_file_path", planPath));
+                PlanResult planResult = claude.send(extractPrompt, PlanResult.class, "haiku");
+                openQuestions = planResult.openQuestions();
+            } catch (Exception ex) {
+                log.warn("Failed to extract open questions for issue #{}", ctx.number(), ex);
+            }
+
             var pushResult = session.exec("smithy-commit-and-push", "Update plan for #" + ctx.number());
             if (pushResult.exitCode() != 0) {
                 log.warn("smithy-commit-and-push failed in {}: {}", session.getContainerName(), pushResult.stderr());
             }
+
+            String authorMention = (ctx.author() != null && !ctx.author().isBlank())
+                ? "@" + ctx.author() + " "
+                : "";
+            var reply = new StringBuilder();
+            if (!openQuestions.isEmpty()) {
+                reply.append("Plan updated. Still have some open questions:\n");
+                for (String q : openQuestions) {
+                    reply.append("\n- ").append(q);
+                }
+                reply.append("\n\n").append(authorMention)
+                    .append("Please clarify, then reply with `approved` or `/approve` to start implementation.");
+            } else {
+                reply.append(authorMention)
+                    .append("Plan updated — no open questions remain. Reply with `approved` or `/approve` to start implementation.");
+            }
+            issueTracker.createIssueComment(ctx.info().owner(), ctx.info().repo(), ctx.number(), reply.toString());
+
         } catch (Exception ex) {
             log.error("Resume refinement failed for issue #{}", ctx.number(), ex);
         }
@@ -431,6 +461,34 @@ public class SmithyWorkflowInstance extends AbstractWorkflowInstance {
             Map.of("pr_number", e.prc().number(), "issue_number", issueId, "comments", commentDicts)
         );
         resumeBuild(e.prc().info(), issueId, e.prc().number(), prompt, false);
+    }
+
+    private void handleIssueCommentInBuild(WorkflowEvent.IssueComment e) {
+        var ctx = e.ctx();
+        try {
+            session.updateState(ContainerState::touch);
+            if (!session.exists()) return;
+
+            String prompt = renderer.render(
+                "build_comment.md.j2",
+                Map.of("issue_number", ctx.number(), "comment_body", e.commentBody())
+            );
+
+            var result = claude.send(prompt);
+            if (result != null && !result.isBlank()) {
+                String authorMention = (ctx.author() != null && !ctx.author().isBlank())
+                    ? "@" + ctx.author() + " "
+                    : "";
+                issueTracker.createIssueComment(
+                    ctx.info().owner(),
+                    ctx.info().repo(),
+                    ctx.number(),
+                    authorMention + result
+                );
+            }
+        } catch (Exception ex) {
+            log.error("Failed to handle issue comment in BUILD for issue #{}", ctx.number(), ex);
+        }
     }
 
     private void handlePrConversationComment(WorkflowEvent.PrConversationComment e) {

--- a/orchestrator/src/main/resources/prompts/build_comment.md.j2
+++ b/orchestrator/src/main/resources/prompts/build_comment.md.j2
@@ -1,0 +1,15 @@
+A user has commented on issue #{{ issue_number }} while you are implementing it.
+
+## Comment
+
+{{ comment_body }}
+
+## Instructions
+
+Read the comment and respond helpfully. You are in the middle of implementing the solution — you have full access to the workspace and the current state of the code.
+
+- If the comment is a question about the implementation or the codebase, answer it directly and concisely.
+- If the comment asks you to change something in your approach, acknowledge it, adjust your plan or implementation accordingly, and summarise what you will do differently.
+- If the comment is just an update or acknowledgment that requires no action, confirm you have noted it.
+
+Write only your reply — a short, clear comment addressed to the user. Do not include greetings or sign-offs. Do not mention the issue number in your reply.


### PR DESCRIPTION
## Summary
Adds a comment-based trigger for the Smithy workflow on GitHub. Previously the only way to start Smithy on an issue was to explicitly assign `smithy-bot` via the GitHub UI. Now you can also trigger it by commenting.

## Trigger phrases
Any of these in a comment on an open issue where smithy-bot is **not** currently assigned:
- `@smithy-bot` (mention the bot by name)
- `/smithy` (slash command prefix)
- `/assign` (slash command prefix)

## Behaviour
- If smithy-bot **is already assigned** → comment is treated as normal (`IssueComment` or approval as before)
- If smithy-bot **is not assigned** and the comment matches a trigger phrase → emits `IssueAssigned`, starting the refinement workflow exactly as if the bot had been assigned via the UI

## Depends on
PR #19 (author tagging) → PR #18 (GitHub integration)

## Test plan
- [ ] Comment `@smithy-bot fix the login button` on an issue → Smithy starts planning
- [ ] Comment `/smithy` on an issue → same
- [ ] Comment on an issue where smithy-bot is already assigned → no duplicate workflow started

🤖 Generated with [Claude Code](https://claude.com/claude-code)