### PR TITLE
Fail closed on missing webhook-secret and paginate GitHub list fetches

### DIFF
--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/vcs/github/GitHubClient.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/vcs/github/GitHubClient.java
@@ -179,7 +179,7 @@ public class GitHubClient implements VcsClient, IssueTrackerClient {
 
     @Override
     public List<ReviewCommentEntry> getReviewComments(String owner, String repo, int prNumber, long reviewId) {
-        var nodes = getList("/repos/%s/%s/pulls/%d/reviews/%d/comments", owner, repo, prNumber, reviewId);
+        var nodes = getList("/repos/%s/%s/pulls/%d/reviews/%d/comments?per_page=100", owner, repo, prNumber, reviewId);
         return nodes.stream().map(this::toReviewCommentEntry).toList();
     }
 
@@ -310,13 +310,14 @@ public class GitHubClient implements VcsClient, IssueTrackerClient {
     }
 
     private List<JsonNode> getList(String pathTemplate, Object... args) {
-        var node = get(pathTemplate, args);
-        if (node.isArray()) {
-            var list = new ArrayList<JsonNode>();
-            for (var item : node) list.add(item);
-            return list;
+        var result = new ArrayList<JsonNode>();
+        String url = pathTemplate.formatted(args);
+        while (url != null) {
+            var page = getPage(url);
+            result.addAll(page.items());
+            url = page.nextUrl();
         }
-        return List.of();
+        return result;
     }
 
     private JsonNode post(String pathTemplate, Map<String, Object> body, Object... args) {

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/WebhookController.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/WebhookController.java
@@ -51,7 +51,11 @@ public class WebhookController {
         @RequestHeader(value = "X-Forgejo-Event", required = false) String forgejoEvent,
         @RequestHeader(value = "X-Gitea-Event", required = false) String giteaEvent
     ) {
-        String secret = vcsConfig.forgejo() != null ? vcsConfig.forgejo().webhookSecret() : "";
+        String secret = vcsConfig.forgejo() != null ? vcsConfig.forgejo().webhookSecret() : null;
+        if (secret == null || secret.isBlank()) {
+            log.warn("Webhook rejected: vcs.forgejo.webhook-secret is not configured");
+            return ResponseEntity.status(403).body("Webhook secret not configured");
+        }
         if (!verifySignature(body, signature, secret)) {
             log.warn("Webhook rejected: invalid HMAC signature");
             return ResponseEntity.status(403).body("Invalid signature");
@@ -135,7 +139,11 @@ public class WebhookController {
             return ResponseEntity.status(404).body("GitHub integration not enabled");
         }
 
-        String secret = vcsConfig.github() != null ? vcsConfig.github().webhookSecret() : "";
+        String secret = vcsConfig.github() != null ? vcsConfig.github().webhookSecret() : null;
+        if (secret == null || secret.isBlank()) {
+            log.warn("GitHub webhook rejected: vcs.github.webhook-secret is not configured");
+            return ResponseEntity.status(403).body("Webhook secret not configured");
+        }
         // GitHub sends "sha256=<hex>" — strip the prefix before verifying
         String signatureHex = signature.startsWith("sha256=") ? signature.substring(7) : signature;
         if (!verifySignature(body, signatureHex, secret)) {

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/github/GitHubClientTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/github/GitHubClientTest.java
@@ -51,4 +51,83 @@ class GitHubClientTest {
         assertEquals("src/App.java", body.path("comments").get(0).path("path").asText());
         assertEquals(42, body.path("comments").get(0).path("line").asInt());
     }
+
+    @Test
+    void getPrReviewsFollowsPaginationLinks() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/api/v3/repos/owner/repo/pulls/5/reviews", exchange -> {
+            String query = exchange.getRequestURI().getQuery();
+            byte[] response;
+            if (query != null && query.contains("page=2")) {
+                response = "[{\"id\":2,\"user\":{\"login\":\"bob\"}}]".getBytes(StandardCharsets.UTF_8);
+            } else {
+                int port = server.getAddress().getPort();
+                exchange
+                    .getResponseHeaders()
+                    .add(
+                        "Link",
+                        "<http://localhost:" +
+                        port +
+                        "/api/v3/repos/owner/repo/pulls/5/reviews?per_page=100&page=2>; rel=\"next\""
+                    );
+                response = "[{\"id\":1,\"user\":{\"login\":\"alice\"}}]".getBytes(StandardCharsets.UTF_8);
+            }
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+
+        try {
+            int port = server.getAddress().getPort();
+            var client = new GitHubClient("http://localhost:" + port, "", "token");
+            var reviews = client.getPrReviews("owner", "repo", 5);
+            assertEquals(2, reviews.size());
+            assertEquals("alice", reviews.get(0).userLogin());
+            assertEquals("bob", reviews.get(1).userLogin());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void getReviewCommentsRequestsFullPagesAndFollowsLinks() throws Exception {
+        AtomicReference<String> firstQuery = new AtomicReference<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/api/v3/repos/owner/repo/pulls/5/reviews/9/comments", exchange -> {
+            String query = exchange.getRequestURI().getQuery();
+            byte[] response;
+            if (query != null && query.contains("page=2")) {
+                response = "[{\"body\":\"second\",\"user\":{\"login\":\"bob\"}}]".getBytes(StandardCharsets.UTF_8);
+            } else {
+                firstQuery.set(query == null ? "" : query);
+                int port = server.getAddress().getPort();
+                exchange
+                    .getResponseHeaders()
+                    .add(
+                        "Link",
+                        "<http://localhost:" +
+                        port +
+                        "/api/v3/repos/owner/repo/pulls/5/reviews/9/comments?per_page=100&page=2>; rel=\"next\""
+                    );
+                response = "[{\"body\":\"first\",\"user\":{\"login\":\"alice\"}}]".getBytes(StandardCharsets.UTF_8);
+            }
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+
+        try {
+            int port = server.getAddress().getPort();
+            var client = new GitHubClient("http://localhost:" + port, "", "token");
+            var comments = client.getReviewComments("owner", "repo", 5, 9);
+            assertTrue(firstQuery.get().contains("per_page=100"), "expected per_page=100, got: " + firstQuery.get());
+            assertEquals(2, comments.size());
+            assertEquals("first", comments.get(0).body());
+            assertEquals("second", comments.get(1).body());
+        } finally {
+            server.stop(0);
+        }
+    }
 }

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/web/WebhookControllerTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/web/WebhookControllerTest.java
@@ -1,0 +1,83 @@
+package dev.smithyai.orchestrator.web;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.smithyai.orchestrator.config.BotConfig;
+import dev.smithyai.orchestrator.config.VcsProviderConfig;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+
+class WebhookControllerTest {
+
+    private static final byte[] BODY = "{}".getBytes(StandardCharsets.UTF_8);
+
+    private static String hmacHex(String secret, byte[] payload) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        return HexFormat.of().formatHex(mac.doFinal(payload));
+    }
+
+    private static WebhookController githubController(String webhookSecret) {
+        var github = new VcsProviderConfig.GitHubProviderConfig("", "", webhookSecret, "smithy-token", null);
+        var vcsConfig = new VcsProviderConfig("github", null, null, null, github);
+        var botConfig = new BotConfig(
+            new BotConfig.BotEntry("smithy-bot", "smithy@example.com"),
+            new BotConfig.BotEntry("architect-bot", "architect@example.com")
+        );
+        var mapper = new GitHubEventMapper(botConfig, vcsConfig, null);
+        return new WebhookController(vcsConfig, null, new ObjectMapper(), null, null, mapper);
+    }
+
+    private static WebhookController forgejoController(String webhookSecret) {
+        var forgejo = new VcsProviderConfig.ForgejoProviderConfig(
+            "http://forgejo.local",
+            "",
+            webhookSecret,
+            "smithy-token",
+            null
+        );
+        var vcsConfig = new VcsProviderConfig("forgejo", null, forgejo, null, null);
+        return new WebhookController(vcsConfig, null, new ObjectMapper(), null, null, null);
+    }
+
+    @Test
+    void githubWebhookRejectedWhenSecretIsNull() {
+        var controller = githubController(null);
+        var response = controller.handleGitHubWebhook(BODY, "sha256=deadbeef", "ping");
+        assertEquals(403, response.getStatusCode().value());
+    }
+
+    @Test
+    void githubWebhookRejectedWhenSecretIsBlank() {
+        var controller = githubController("");
+        var response = controller.handleGitHubWebhook(BODY, "sha256=deadbeef", "ping");
+        assertEquals(403, response.getStatusCode().value());
+    }
+
+    @Test
+    void githubWebhookAcceptsValidSignature() throws Exception {
+        var controller = githubController("s3cret");
+        String signature = "sha256=" + hmacHex("s3cret", BODY);
+        var response = controller.handleGitHubWebhook(BODY, signature, "ping");
+        assertEquals(200, response.getStatusCode().value());
+    }
+
+    @Test
+    void forgejoWebhookRejectedWhenSecretNotConfigured() {
+        var controller = forgejoController("");
+        var response = controller.handleWebhook(BODY, "deadbeef", "ping", null);
+        assertEquals(403, response.getStatusCode().value());
+    }
+
+    @Test
+    void forgejoWebhookAcceptsValidSignature() throws Exception {
+        var controller = forgejoController("s3cret");
+        String signature = hmacHex("s3cret", BODY);
+        var response = controller.handleWebhook(BODY, signature, "ping", null);
+        assertEquals(200, response.getStatusCode().value());
+    }
+}


### PR DESCRIPTION
Fixes #29.

## What

**1. Webhook handlers fail closed with 403 when `webhook-secret` is not configured** (`WebhookController`)

The Forgejo and GitHub handlers passed an empty/null secret into `verifySignature`, where `HmacSHA256` throws `IllegalArgumentException: Empty key` (or NPE for null) — uncaught, so every delivery returned HTTP 500 with a stack trace. Both handlers now reject with a clear 403 and a "webhook-secret is not configured" warning, matching the existing GitLab handler behavior.

**2. `GitHubClient.getList()` follows `Link: rel="next"` pagination** (`GitHubClient`)

`getList()` fetched one page and stopped. Now it reuses the existing `getPage()` helper (already used by `fetchPaged()` for issue comments) to walk all pages. Additionally `getReviewComments()` now requests `per_page=100` — it previously used GitHub's default page size of **30**, so a submitted review with >30 inline comments silently lost the rest. This also fixes `getLatestReviewComments()` picking a stale review when a PR has >100 reviews.

## Tests

Written test-first (verified failing against the current code for the exact defect symptoms — `IllegalArgumentException: Empty key`, NPE, and truncated lists — before the fix):

- `WebhookControllerTest`: null/blank secret → 403 for both GitHub and Forgejo endpoints; valid HMAC signature still → 200 (positive controls).
- `GitHubClientTest`: `getPrReviews` follows `Link` pagination across pages; `getReviewComments` sends `per_page=100` and follows pagination. Uses the same embedded-`HttpServer` pattern as the existing review test.

`:backend:test`: 23 tests, 0 failures.

## Notes for review

- Rejecting on unconfigured secret is a behavior change for any deployment that (accidentally) ran without a secret — but such deployments were already broken: every webhook returned 500.
- `findPrByHead()` also goes through the paginating `getList()` now; with the `head=` filter this is at most a page, so no extra requests in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oRKV9Qh51ZrNJt5UYdUgJ