### PR TITLE
Run tasks on Kubernetes as an alternative to Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ python3 scripts/setup_instance.py
 python3 scripts/setup_repo.py owner/repo
 ```
 
+## Running on Kubernetes
+
+For a cluster deployment, the orchestrator runs in `kubernetes` runtime mode and
+launches each task as a Pod. A Helm chart and a Kustomize base are provided under
+[`deploy/`](deploy/README.md), including namespaced RBAC for task Pods and
+optional bundled Forgejo and knowledgebase.
+
+```bash
+helm install smithy deploy/helm/smithy -n smithy --create-namespace -f my-values.yaml
+```
+
+Or with Kustomize (edit `deploy/k8s/secret.yaml` first):
+
+```bash
+kubectl apply -k deploy/k8s
+```
+
+See [`deploy/README.md`](deploy/README.md) for required secrets, runtime
+selection (`SMITHY_RUNTIME=kubernetes`), RBAC, bring-your-own-VCS vs bundled
+Forgejo, the knowledgebase, and exposing the service via Ingress or
+`kubectl port-forward svc/smithy 8080:8080`.
+
 ## Documentation
 
 - **Setup**: [Demo](https://smithy-ai.github.io/smithy-ai/setup/demo/) · [GitHub](https://smithy-ai.github.io/smithy-ai/setup/github/) · [GitLab](https://smithy-ai.github.io/smithy-ai/setup/gitlab/) · [Forgejo](https://smithy-ai.github.io/smithy-ai/setup/forgejo/)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,233 @@
+# Deploying Smithy-AI on Kubernetes
+
+The Smithy-AI orchestrator is a Spring Boot service (`ghcr.io/smithy-ai/orchestrator`)
+that turns VCS issues and webhooks into autonomous coding tasks. On Kubernetes it
+launches **each task as a Pod** (a fresh Java runtime), so the orchestrator needs
+RBAC to manage Pods in its namespace. It keeps **no database** — task state lives
+in the task Pods themselves.
+
+This directory offers two install paths:
+
+- **Helm chart** — `deploy/helm/smithy` (recommended; configurable, optional
+  bundled Forgejo + knowledgebase).
+- **Kustomize base** — `deploy/k8s` (plain manifests equivalent to a default
+  Helm render; good for GitOps or when you don't use Helm).
+
+Both are kept consistent: same names, namespace (`smithy`), port (`8080`), env
+vars, and Secret keys.
+
+---
+
+## Quick start (Helm)
+
+```bash
+helm install smithy deploy/helm/smithy \
+  -n smithy --create-namespace \
+  -f my-values.yaml
+```
+
+Minimal `my-values.yaml` for an existing Forgejo:
+
+```yaml
+config:
+  vcs:
+    provider: forgejo
+    forgejo:
+      url: https://forgejo.internal:3000
+      externalUrl: https://git.example.com
+
+secrets:
+  claudeCodeOauthToken: "sk-..."     # from `claude setup-token`
+  forgejo:
+    webhookSecret: "..."
+    smithyToken: "..."
+    architectToken: "..."            # optional
+```
+
+## Quick start (Kustomize)
+
+```bash
+# 1. Edit deploy/k8s/secret.yaml — replace every CHANGE_ME (or delete it and
+#    provide your own Secret named "smithy-secrets").
+# 2. Adjust deploy/k8s/configmap.yaml for your VCS.
+kubectl apply -k deploy/k8s
+```
+
+The kustomize base creates the `smithy` namespace, ServiceAccount, Role +
+RoleBinding, ConfigMap, Secret, Deployment, and Service.
+
+---
+
+## Required secrets
+
+Set at least one Claude credential and the tokens matching your VCS provider.
+
+| Env var (Secret key)        | Purpose                                   | Required |
+|-----------------------------|-------------------------------------------|----------|
+| `CLAUDE_CODE_OAUTH_TOKEN`   | Claude Code OAuth token (`claude setup-token`) | one of these two |
+| `ANTHROPIC_API_KEY`         | Anthropic API key                         | one of these two |
+| `WEBHOOK_SECRET`            | Forgejo webhook HMAC secret               | if provider=forgejo |
+| `SMITHY_FORGEJO_TOKEN`      | Smithy bot Forgejo token                  | if provider=forgejo |
+| `ARCHITECT_FORGEJO_TOKEN`   | Architect bot Forgejo token               | optional |
+| `GITLAB_WEBHOOK_SECRET` / `SMITHY_GITLAB_TOKEN` / `ARCHITECT_GITLAB_TOKEN` | GitLab | if provider=gitlab |
+| `GITHUB_WEBHOOK_SECRET` / `SMITHY_GITHUB_TOKEN` / `ARCHITECT_GITHUB_TOKEN` | GitHub | if provider=github |
+
+### Bring your own Secret (recommended for production)
+
+Rather than templating credentials into a chart-managed Secret, create the
+Secret out of band and reference it:
+
+```bash
+kubectl create secret generic smithy-secrets -n smithy \
+  --from-literal=CLAUDE_CODE_OAUTH_TOKEN=sk-... \
+  --from-literal=WEBHOOK_SECRET=... \
+  --from-literal=SMITHY_FORGEJO_TOKEN=...
+```
+
+```yaml
+# my-values.yaml
+secrets:
+  existingSecret: smithy-secrets
+```
+
+When `secrets.existingSecret` is set the chart does **not** render its own
+Secret; the Deployment reads env from the named Secret via `envFrom`. Make sure
+it contains the keys listed above.
+
+---
+
+## Selecting the runtime
+
+The orchestrator supports `docker` and `kubernetes` runtimes. On a cluster it
+**must** run in kubernetes mode so tasks are launched as Pods:
+
+```yaml
+runtime:
+  type: kubernetes            # sets SMITHY_RUNTIME=kubernetes
+  kubernetes:
+    namespace: ""             # empty = release namespace (recommended)
+    taskImage: ghcr.io/smithy-ai/claude-task-default:dev
+    taskServiceAccount: ""    # optional SA for task Pods
+    imagePullSecret: ""       # optional pull secret for the task image
+```
+
+`SMITHY_RUNTIME=kubernetes` and `KUBERNETES_NAMESPACE` (defaulting to the release
+namespace) are injected into the Deployment automatically. No Docker socket is
+mounted.
+
+---
+
+## RBAC
+
+The orchestrator needs to create, watch, delete, read logs from, and exec into
+task Pods. The chart (`rbac.create: true`) and the kustomize base create a
+**namespaced** `Role` + `RoleBinding` — there is **no ClusterRole**. The grant is
+limited to the orchestrator's own namespace:
+
+```yaml
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+```
+
+If you disable the bundled RBAC (`rbac.create: false`), you must grant the
+orchestrator ServiceAccount equivalent permissions in the namespace where task
+Pods run (`runtime.kubernetes.namespace`, default = release namespace), or task
+launching will fail.
+
+---
+
+## Bring-your-own VCS vs bundled Forgejo
+
+**Bring your own** (production default): point `config.vcs.*` at your existing
+Forgejo / GitLab / GitHub and provide the matching tokens. No extra workloads are
+deployed.
+
+**Bundled Forgejo** (dev only): for a self-contained stack, enable the bundled,
+minimal Forgejo Deployment + Service (ports 3000, 22) + PVC:
+
+```yaml
+forgejo:
+  enabled: true
+```
+
+It is reachable in-cluster at `http://forgejo:3000` — which is already the
+default `config.vcs.forgejo.url`. Not intended for production.
+
+---
+
+## Enabling the knowledgebase
+
+The knowledgebase is an optional MCP server the orchestrator can query for
+codebase context. Two independent switches:
+
+- `config.knowledgebase.enabled` — tells the **orchestrator** to use a
+  knowledgebase at `config.knowledgebase.url`.
+- `knowledgebase.enabled` — **deploys** the bundled knowledgebase (image
+  `ghcr.io/smithy-ai/knowledgebase:dev`, port 8000, PVC for `/app/vectorstore`,
+  a `/config/knowledgebase.yml`).
+
+To run the bundled one and point the orchestrator at it:
+
+```yaml
+config:
+  knowledgebase:
+    enabled: true
+    url: http://knowledgebase:8000/mcp
+
+knowledgebase:
+  enabled: true
+  openaiApiKey: "sk-..."     # required for embeddings
+  # vcsUrl / vcsToken / webhookSecret default to the Forgejo url + smithy token
+```
+
+The bundled knowledgebase ships a placeholder `knowledgebase.yml` with an empty
+repository list; edit the generated ConfigMap (or supply your own) to index
+repos.
+
+---
+
+## Exposing the orchestrator
+
+The orchestrator listens on port 8080. Endpoints: `GET /api/health` (health),
+`/webhooks/{forgejo,gitlab,github}` (VCS webhooks), `/api/dashboard/*` and `/`
+(dashboard + static frontend).
+
+### Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  host: smithy.example.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  tls:
+    enabled: true
+    secretName: smithy-tls
+```
+
+The Ingress backend targets the `smithy` Service on port 8080. Your VCS must be
+able to reach the webhook path over this host.
+
+### Port-forward (no Ingress)
+
+```bash
+kubectl port-forward svc/smithy -n smithy 8080:8080
+# then: http://localhost:8080/  (dashboard)
+#       curl http://localhost:8080/api/health
+```
+
+---
+
+## Validation
+
+```bash
+helm lint deploy/helm/smithy
+helm template smithy deploy/helm/smithy -n smithy
+kubectl kustomize deploy/k8s
+```

--- a/deploy/helm/smithy/.helmignore
+++ b/deploy/helm/smithy/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+*.tmproj
+*.orig
+*.bak
+*~

--- a/deploy/helm/smithy/Chart.yaml
+++ b/deploy/helm/smithy/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: smithy
+description: >-
+  Smithy-AI orchestrator — a Spring Boot service that turns VCS issues and
+  webhooks into autonomous coding tasks. On Kubernetes it launches each task as
+  a Pod, so it ships with namespaced RBAC to manage those Pods. Optional bundled
+  Forgejo and knowledgebase MCP server for a self-contained dev deployment.
+type: application
+
+# The chart's own version. Bump on any change to the templates/values.
+version: 0.1.0
+
+# The version of the orchestrator application this chart deploys by default.
+# Overridable via image.tag in values.yaml.
+appVersion: "dev"
+
+home: https://github.com/smithy-ai/smithy-ai
+sources:
+  - https://github.com/smithy-ai/smithy-ai
+keywords:
+  - smithy
+  - orchestrator
+  - ai
+  - coding-agent
+maintainers:
+  - name: smithy-ai

--- a/deploy/helm/smithy/templates/NOTES.txt
+++ b/deploy/helm/smithy/templates/NOTES.txt
@@ -1,0 +1,54 @@
+Smithy-AI orchestrator has been deployed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+1. Check the rollout:
+
+   kubectl rollout status deployment/{{ include "smithy.fullname" . }} -n {{ .Release.Namespace }}
+
+2. Reach the orchestrator (health at GET /api/health, dashboard at /):
+
+{{- if .Values.ingress.enabled }}
+
+   http{{ if .Values.ingress.tls.enabled }}s{{ end }}://{{ .Values.ingress.host }}{{ .Values.ingress.path }}
+{{- else }}
+
+   The Service is type {{ .Values.service.type }}. Port-forward to reach it locally:
+
+   kubectl port-forward svc/{{ include "smithy.fullname" . }} -n {{ .Release.Namespace }} 8080:{{ .Values.service.port }}
+
+   Then open http://localhost:8080/ (dashboard) or curl http://localhost:8080/api/health
+{{- end }}
+
+3. Runtime:
+
+   SMITHY_RUNTIME is set to "{{ .Values.runtime.type }}". Task Pods are created in
+   namespace "{{ include "smithy.taskNamespace" . }}" using image
+   "{{ .Values.runtime.kubernetes.taskImage }}".
+{{- if .Values.rbac.create }}
+   A namespaced Role + RoleBinding grant the orchestrator ServiceAccount
+   ({{ include "smithy.serviceAccountName" . }}) permission to manage those Pods
+   (pods, pods/log get/list/watch/create/delete and pods/exec create).
+{{- else }}
+   NOTE: rbac.create is false. Ensure the ServiceAccount
+   "{{ include "smithy.serviceAccountName" . }}" has pods / pods/log / pods/exec
+   permissions in namespace "{{ include "smithy.taskNamespace" . }}", or task
+   launching will fail.
+{{- end }}
+
+4. Secrets:
+
+{{- if .Values.secrets.existingSecret }}
+   Using existing Secret "{{ .Values.secrets.existingSecret }}". Make sure it
+   contains the expected keys (CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY, plus
+   the {{ .Values.config.vcs.provider }} token/webhook keys).
+{{- else }}
+   {{- if and (not .Values.secrets.claudeCodeOauthToken) (not .Values.secrets.anthropicApiKey) }}
+   WARNING: neither claudeCodeOauthToken nor anthropicApiKey is set. The
+   orchestrator cannot run Claude tasks without one. Set it via -f values.yaml or
+   --set secrets.claudeCodeOauthToken=... and upgrade.
+   {{- else }}
+   Credentials were templated into Secret "{{ include "smithy.secretName" . }}".
+   For production, prefer secrets.existingSecret and manage the Secret out of band.
+   {{- end }}
+{{- end }}
+
+See deploy/README.md for the full configuration guide.

--- a/deploy/helm/smithy/templates/_helpers.tpl
+++ b/deploy/helm/smithy/templates/_helpers.tpl
@@ -1,0 +1,89 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "smithy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec).
+*/}}
+{{- define "smithy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "smithy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "smithy.labels" -}}
+helm.sh/chart: {{ include "smithy.chart" . }}
+{{ include "smithy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: smithy
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "smithy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "smithy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+The name of the orchestrator ServiceAccount to use.
+*/}}
+{{- define "smithy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "smithy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+The name of the Secret the orchestrator reads env from. Points at the
+user-supplied existingSecret when set, otherwise the chart-templated Secret.
+*/}}
+{{- define "smithy.secretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- printf "%s-secrets" (include "smithy.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+The name of the orchestrator ConfigMap.
+*/}}
+{{- define "smithy.configMapName" -}}
+{{- printf "%s-config" (include "smithy.fullname" .) }}
+{{- end }}
+
+{{/*
+Namespace used for task Pods. Falls back to the release namespace.
+*/}}
+{{- define "smithy.taskNamespace" -}}
+{{- default .Release.Namespace .Values.runtime.kubernetes.namespace }}
+{{- end }}

--- a/deploy/helm/smithy/templates/configmap.yaml
+++ b/deploy/helm/smithy/templates/configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "smithy.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+data:
+  # Runtime
+  SMITHY_RUNTIME: {{ .Values.runtime.type | quote }}
+  KUBERNETES_NAMESPACE: {{ include "smithy.taskNamespace" . | quote }}
+  TASK_IMAGE: {{ .Values.runtime.kubernetes.taskImage | quote }}
+  {{- with .Values.runtime.kubernetes.taskServiceAccount }}
+  TASK_SERVICE_ACCOUNT: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.runtime.kubernetes.imagePullSecret }}
+  TASK_IMAGE_PULL_SECRET: {{ . | quote }}
+  {{- end }}
+
+  # VCS provider selection + non-secret URLs
+  VCS_PROVIDER: {{ .Values.config.vcs.provider | quote }}
+  FORGEJO_URL: {{ .Values.config.vcs.forgejo.url | quote }}
+  FORGEJO_EXTERNAL_URL: {{ .Values.config.vcs.forgejo.externalUrl | quote }}
+  GITLAB_URL: {{ .Values.config.vcs.gitlab.url | quote }}
+  GITLAB_EXTERNAL_URL: {{ .Values.config.vcs.gitlab.externalUrl | quote }}
+  GITLAB_TOKEN_TYPE: {{ .Values.config.vcs.gitlab.tokenType | quote }}
+  GITHUB_URL: {{ .Values.config.vcs.github.url | quote }}
+  GITHUB_EXTERNAL_URL: {{ .Values.config.vcs.github.externalUrl | quote }}
+
+  # Knowledgebase
+  KNOWLEDGEBASE_ENABLED: {{ .Values.config.knowledgebase.enabled | quote }}
+  KNOWLEDGEBASE_URL: {{ .Values.config.knowledgebase.url | quote }}
+  KNOWLEDGEBASE_TOOL_NAME: {{ .Values.config.knowledgebase.toolName | quote }}
+
+  # Bots
+  SMITHY_BOT_USER: {{ .Values.config.bots.smithy.user | quote }}
+  SMITHY_BOT_EMAIL: {{ .Values.config.bots.smithy.email | quote }}
+  ARCHITECT_BOT_USER: {{ .Values.config.bots.architect.user | quote }}
+  ARCHITECT_BOT_EMAIL: {{ .Values.config.bots.architect.email | quote }}

--- a/deploy/helm/smithy/templates/deployment.yaml
+++ b/deploy/helm/smithy/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "smithy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: orchestrator
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "smithy.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: orchestrator
+  template:
+    metadata:
+      labels:
+        {{- include "smithy.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: orchestrator
+      annotations:
+        # Roll the Deployment when config/secret content changes.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.secrets.existingSecret }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "smithy.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: orchestrator
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            # Ensure the runtime is kubernetes and tasks land in this namespace
+            # unless the operator pinned a different one in values.
+            - name: SMITHY_RUNTIME
+              value: {{ .Values.runtime.type | quote }}
+            - name: KUBERNETES_NAMESPACE
+              value: {{ include "smithy.taskNamespace" . | quote }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "smithy.configMapName" . }}
+            - secretRef:
+                name: {{ include "smithy.secretName" . }}
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/helm/smithy/templates/forgejo.yaml
+++ b/deploy/helm/smithy/templates/forgejo.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.forgejo.enabled -}}
+{{- $name := printf "%s-forgejo" (include "smithy.fullname" .) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: forgejo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "smithy.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: forgejo
+  template:
+    metadata:
+      labels:
+        {{- include "smithy.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: forgejo
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: forgejo
+          image: "{{ .Values.forgejo.image.repository }}:{{ .Values.forgejo.image.tag }}"
+          imagePullPolicy: {{ .Values.forgejo.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+            - name: ssh
+              containerPort: 22
+          env:
+            - name: FORGEJO__webhook__ALLOWED_HOST_LIST
+              value: "*"
+            - name: FORGEJO__actions__ENABLED
+              value: "true"
+            - name: FORGEJO__ui__DEFAULT_SHOW_FULL_NAME
+              value: "true"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          {{- with .Values.forgejo.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: data
+        {{- if .Values.forgejo.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ $name }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+{{- if .Values.forgejo.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: forgejo
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.forgejo.persistence.size }}
+  {{- with .Values.forgejo.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: forgejo
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: forgejo
+spec:
+  type: {{ .Values.forgejo.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.forgejo.service.httpPort }}
+      targetPort: http
+    - name: ssh
+      port: {{ .Values.forgejo.service.sshPort }}
+      targetPort: ssh
+  selector:
+    {{- include "smithy.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: forgejo
+{{- end }}

--- a/deploy/helm/smithy/templates/ingress.yaml
+++ b/deploy/helm/smithy/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "smithy.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      {{- with .Values.ingress.tls.secretName }}
+      secretName: {{ . }}
+      {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+{{- end }}

--- a/deploy/helm/smithy/templates/knowledgebase.yaml
+++ b/deploy/helm/smithy/templates/knowledgebase.yaml
@@ -1,0 +1,140 @@
+{{- if .Values.knowledgebase.enabled -}}
+{{- $name := printf "%s-knowledgebase" (include "smithy.fullname" .) -}}
+{{- $vcsUrl := .Values.knowledgebase.vcsUrl | default .Values.config.vcs.forgejo.url -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: knowledgebase
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "smithy.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: knowledgebase
+  template:
+    metadata:
+      labels:
+        {{- include "smithy.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: knowledgebase
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: knowledgebase
+          image: "{{ .Values.knowledgebase.image.repository }}:{{ .Values.knowledgebase.image.tag }}"
+          imagePullPolicy: {{ .Values.knowledgebase.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+          env:
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $name }}
+                  key: OPENAI_API_KEY
+            - name: VCS_URL
+              value: {{ $vcsUrl | quote }}
+            - name: VCS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $name }}
+                  key: VCS_TOKEN
+            - name: WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $name }}
+                  key: WEBHOOK_SECRET
+          volumeMounts:
+            - name: vectorstore
+              mountPath: /app/vectorstore
+            - name: config
+              mountPath: /config
+              readOnly: true
+          {{- with .Values.knowledgebase.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $name }}
+        - name: vectorstore
+        {{- if .Values.knowledgebase.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ $name }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: knowledgebase
+type: Opaque
+stringData:
+  OPENAI_API_KEY: {{ .Values.knowledgebase.openaiApiKey | quote }}
+  VCS_TOKEN: {{ .Values.knowledgebase.vcsToken | default .Values.secrets.forgejo.smithyToken | quote }}
+  WEBHOOK_SECRET: {{ .Values.knowledgebase.webhookSecret | default .Values.secrets.forgejo.webhookSecret | quote }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: knowledgebase
+data:
+  # Minimal placeholder config. Replace with your repository list; see the
+  # knowledgebase docs for the schema.
+  knowledgebase.yml: |
+    repositories: []
+{{- if .Values.knowledgebase.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: knowledgebase
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.knowledgebase.persistence.size }}
+  {{- with .Values.knowledgebase.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: knowledgebase
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: knowledgebase
+spec:
+  type: {{ .Values.knowledgebase.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.knowledgebase.service.port }}
+      targetPort: http
+  selector:
+    {{- include "smithy.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: knowledgebase
+{{- end }}

--- a/deploy/helm/smithy/templates/rbac.yaml
+++ b/deploy/helm/smithy/templates/rbac.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "smithy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+rules:
+  # Manage the lifecycle of task Pods and read their logs.
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  # Exec into task Pods (used to stream the task runtime).
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "smithy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "smithy.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "smithy.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/smithy/templates/secret.yaml
+++ b/deploy/helm/smithy/templates/secret.yaml
@@ -1,0 +1,29 @@
+{{- if not .Values.secrets.existingSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "smithy.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  # Claude credentials
+  CLAUDE_CODE_OAUTH_TOKEN: {{ .Values.secrets.claudeCodeOauthToken | quote }}
+  ANTHROPIC_API_KEY: {{ .Values.secrets.anthropicApiKey | quote }}
+
+  # Forgejo credentials
+  WEBHOOK_SECRET: {{ .Values.secrets.forgejo.webhookSecret | quote }}
+  SMITHY_FORGEJO_TOKEN: {{ .Values.secrets.forgejo.smithyToken | quote }}
+  ARCHITECT_FORGEJO_TOKEN: {{ .Values.secrets.forgejo.architectToken | quote }}
+
+  # GitLab credentials
+  GITLAB_WEBHOOK_SECRET: {{ .Values.secrets.gitlab.webhookSecret | quote }}
+  SMITHY_GITLAB_TOKEN: {{ .Values.secrets.gitlab.smithyToken | quote }}
+  ARCHITECT_GITLAB_TOKEN: {{ .Values.secrets.gitlab.architectToken | quote }}
+
+  # GitHub credentials
+  GITHUB_WEBHOOK_SECRET: {{ .Values.secrets.github.webhookSecret | quote }}
+  SMITHY_GITHUB_TOKEN: {{ .Values.secrets.github.smithyToken | quote }}
+  ARCHITECT_GITHUB_TOKEN: {{ .Values.secrets.github.architectToken | quote }}
+{{- end }}

--- a/deploy/helm/smithy/templates/service.yaml
+++ b/deploy/helm/smithy/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "smithy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: orchestrator
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "smithy.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: orchestrator

--- a/deploy/helm/smithy/templates/serviceaccount.yaml
+++ b/deploy/helm/smithy/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "smithy.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "smithy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/smithy/values.yaml
+++ b/deploy/helm/smithy/values.yaml
@@ -1,0 +1,230 @@
+# Default values for the smithy chart.
+# This is a YAML-formatted file. Override any of these with `-f my-values.yaml`
+# or `--set key=value` at install time.
+
+# -- Number of orchestrator replicas. The orchestrator holds no shared state of
+# its own (task state lives in the task Pods), but running more than one replica
+# means webhooks may be delivered to any replica; keep at 1 unless you have set
+# up a coordination strategy.
+replicaCount: 1
+
+image:
+  # -- Orchestrator container image repository. Published by CI.
+  repository: ghcr.io/smithy-ai/orchestrator
+  # -- Image tag. Overrides the chart appVersion when set.
+  tag: dev
+  # -- Image pull policy.
+  pullPolicy: IfNotPresent
+
+# -- Optional list of imagePullSecrets applied to every workload Pod in this
+# chart (orchestrator, forgejo, knowledgebase). Format: [{name: my-secret}].
+imagePullSecrets: []
+
+# -- Override the chart name used in resource names.
+nameOverride: ""
+# -- Override the fully qualified app name used in resource names.
+fullnameOverride: ""
+
+# -- Resource requests/limits for the orchestrator container.
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+service:
+  # -- Kubernetes Service type for the orchestrator.
+  type: ClusterIP
+  # -- Service port. The orchestrator listens on 8080.
+  port: 8080
+
+# ----------------------------------------------------------------------------
+# Runtime — how the orchestrator launches tasks.
+# ----------------------------------------------------------------------------
+runtime:
+  # -- Task runtime: "kubernetes" (launch each task as a Pod, the default and
+  # only supported mode on a cluster) or "docker" (only meaningful when the
+  # orchestrator can reach a Docker socket — not used in this chart).
+  type: kubernetes
+
+  kubernetes:
+    # -- Namespace in which task Pods are created. Empty string means the
+    # orchestrator uses its own namespace (the release namespace), which is the
+    # recommended setup and what the bundled RBAC Role grants access to.
+    namespace: ""
+    # -- Image used for task Pods (the Claude task runtime).
+    taskImage: ghcr.io/smithy-ai/claude-task-default:dev
+    # -- ServiceAccount name assigned to task Pods. Empty string means the
+    # cluster default ServiceAccount is used for task Pods.
+    taskServiceAccount: ""
+    # -- Optional imagePullSecret name passed to task Pods so they can pull the
+    # task image from a private registry.
+    imagePullSecret: ""
+
+# ----------------------------------------------------------------------------
+# Non-secret application config (rendered into a ConfigMap, injected via envFrom)
+# ----------------------------------------------------------------------------
+config:
+  vcs:
+    # -- VCS provider: forgejo | gitlab | github.
+    provider: forgejo
+    forgejo:
+      # -- Internal URL the orchestrator uses to reach Forgejo.
+      url: http://forgejo:3000
+      # -- External URL used in links shown to users / in webhook registration.
+      externalUrl: http://localhost:3000
+    gitlab:
+      url: ""
+      externalUrl: ""
+      # -- GitLab token type (e.g. oauth2 or pat).
+      tokenType: ""
+    github:
+      url: ""
+      externalUrl: ""
+  bots:
+    smithy:
+      # -- Username of the Smithy bot account in the VCS.
+      user: smithy
+      # -- Git commit email for the Smithy bot.
+      email: ""
+    architect:
+      # -- Username of the Architect bot account in the VCS.
+      user: architect
+      # -- Git commit email for the Architect bot.
+      email: ""
+  knowledgebase:
+    # -- Point the orchestrator at a knowledgebase MCP server. This toggle only
+    # tells the orchestrator to use one; set knowledgebase.enabled (bottom of
+    # this file) to also deploy the bundled knowledgebase in this release.
+    enabled: false
+    # -- MCP endpoint of the knowledgebase. Defaults to the bundled service.
+    url: http://knowledgebase:8000/mcp
+    # -- MCP tool name exposed by the knowledgebase.
+    toolName: searchKnowledge
+
+# ----------------------------------------------------------------------------
+# Secrets (rendered into a Secret, injected via envFrom) — DO NOT commit real
+# values. Prefer `existingSecret` in production and manage the Secret out of band.
+# ----------------------------------------------------------------------------
+secrets:
+  # -- Name of a pre-existing Secret to use instead of templating one from the
+  # values below. When set, the chart will NOT render its own Secret; the named
+  # Secret must contain the same keys the orchestrator expects (see
+  # templates/secret.yaml for the key names).
+  existingSecret: ""
+
+  # Claude credentials — set at least one.
+  # -- Claude Code OAuth token (from `claude setup-token`).
+  claudeCodeOauthToken: ""
+  # -- Anthropic API key (alternative to the OAuth token).
+  anthropicApiKey: ""
+
+  # VCS credentials — set the ones matching config.vcs.provider.
+  forgejo:
+    # -- Webhook HMAC secret for Forgejo webhooks.
+    webhookSecret: ""
+    # -- Smithy bot Forgejo access token.
+    smithyToken: ""
+    # -- Architect bot Forgejo access token.
+    architectToken: ""
+  gitlab:
+    webhookSecret: ""
+    smithyToken: ""
+    architectToken: ""
+  github:
+    webhookSecret: ""
+    smithyToken: ""
+    architectToken: ""
+
+serviceAccount:
+  # -- Create a ServiceAccount for the orchestrator.
+  create: true
+  # -- Name of the orchestrator ServiceAccount. Generated from the release name
+  # when empty.
+  name: ""
+  # -- Extra annotations for the ServiceAccount.
+  annotations: {}
+
+rbac:
+  # -- Create a namespaced Role + RoleBinding granting the orchestrator the
+  # permissions it needs to launch and manage task Pods. No ClusterRole is used.
+  create: true
+
+ingress:
+  # -- Expose the orchestrator via an Ingress.
+  enabled: false
+  # -- IngressClass name.
+  className: ""
+  # -- Extra annotations (e.g. cert-manager, nginx tweaks).
+  annotations: {}
+  # -- Hostname to route to the orchestrator.
+  host: smithy.example.com
+  # -- Path prefix.
+  path: /
+  # -- Kubernetes Ingress pathType.
+  pathType: Prefix
+  tls:
+    # -- Enable TLS for the host above.
+    enabled: false
+    # -- Secret holding the TLS cert/key for the host.
+    secretName: ""
+
+# ----------------------------------------------------------------------------
+# Bundled Forgejo (dev only). Enable for a self-contained stack without an
+# external VCS. Not intended for production.
+# ----------------------------------------------------------------------------
+forgejo:
+  # -- Deploy a bundled Forgejo instance.
+  enabled: false
+  image:
+    repository: codeberg.org/forgejo/forgejo
+    tag: "14"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    # -- HTTP port.
+    httpPort: 3000
+    # -- SSH port.
+    sshPort: 22
+  persistence:
+    # -- Persist /data on a PVC.
+    enabled: true
+    size: 10Gi
+    # -- StorageClass; empty uses the cluster default.
+    storageClass: ""
+  resources: {}
+
+# ----------------------------------------------------------------------------
+# Bundled knowledgebase MCP server (optional). Enable to deploy it in-cluster;
+# also set config.knowledgebase.enabled so the orchestrator uses it.
+# ----------------------------------------------------------------------------
+knowledgebase:
+  # -- Deploy the bundled knowledgebase MCP server.
+  enabled: false
+  image:
+    repository: ghcr.io/smithy-ai/knowledgebase
+    tag: dev
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    # -- Port the knowledgebase listens on.
+    port: 8000
+  # -- OpenAI API key used by the knowledgebase for embeddings (secret).
+  openaiApiKey: ""
+  # -- VCS base URL the knowledgebase indexes from. Defaults to the configured
+  # Forgejo url when empty.
+  vcsUrl: ""
+  # -- VCS access token for the knowledgebase. Defaults to the Smithy token when
+  # empty.
+  vcsToken: ""
+  # -- Webhook secret for the knowledgebase. Defaults to the provider webhook
+  # secret when empty.
+  webhookSecret: ""
+  persistence:
+    # -- Persist /app/vectorstore on a PVC.
+    enabled: true
+    size: 5Gi
+    storageClass: ""
+  resources: {}

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: smithy-config
+  labels:
+    app.kubernetes.io/name: smithy
+    app.kubernetes.io/part-of: smithy
+data:
+  # Runtime — launch each task as a Pod in this namespace.
+  SMITHY_RUNTIME: "kubernetes"
+  KUBERNETES_NAMESPACE: "smithy"
+  TASK_IMAGE: "ghcr.io/smithy-ai/claude-task-default:dev"
+
+  # VCS provider selection + non-secret URLs. Default provider is forgejo;
+  # edit these for your VCS (or switch VCS_PROVIDER to gitlab/github and fill
+  # the matching URLs).
+  VCS_PROVIDER: "forgejo"
+  FORGEJO_URL: "http://forgejo:3000"
+  FORGEJO_EXTERNAL_URL: "http://localhost:3000"
+  GITLAB_URL: ""
+  GITLAB_EXTERNAL_URL: ""
+  GITLAB_TOKEN_TYPE: ""
+  GITHUB_URL: ""
+  GITHUB_EXTERNAL_URL: ""
+
+  # Knowledgebase (disabled by default).
+  KNOWLEDGEBASE_ENABLED: "false"
+  KNOWLEDGEBASE_URL: "http://knowledgebase:8000/mcp"
+  KNOWLEDGEBASE_TOOL_NAME: "searchKnowledge"
+
+  # Bots.
+  SMITHY_BOT_USER: "smithy"
+  SMITHY_BOT_EMAIL: ""
+  ARCHITECT_BOT_USER: "architect"
+  ARCHITECT_BOT_EMAIL: ""

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smithy
+  labels:
+    app.kubernetes.io/name: smithy
+    app.kubernetes.io/part-of: smithy
+    app.kubernetes.io/component: orchestrator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: smithy
+      app.kubernetes.io/component: orchestrator
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: smithy
+        app.kubernetes.io/component: orchestrator
+    spec:
+      serviceAccountName: smithy
+      containers:
+        - name: orchestrator
+          image: ghcr.io/smithy-ai/orchestrator:dev
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: SMITHY_RUNTIME
+              value: "kubernetes"
+            - name: KUBERNETES_NAMESPACE
+              value: "smithy"
+          envFrom:
+            - configMapRef:
+                name: smithy-config
+            - secretRef:
+                name: smithy-secrets
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# All resources land in the smithy namespace.
+namespace: smithy
+
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - rbac.yaml
+  - configmap.yaml
+  - secret.yaml
+  - deployment.yaml
+  - service.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/managed-by: kustomize
+    includeSelectors: false

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: smithy
+  labels:
+    app.kubernetes.io/part-of: smithy

--- a/deploy/k8s/rbac.yaml
+++ b/deploy/k8s/rbac.yaml
@@ -1,0 +1,32 @@
+# Namespaced RBAC letting the orchestrator manage task Pods in its own namespace.
+# No ClusterRole is used — the grant is scoped to the smithy namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: smithy
+  labels:
+    app.kubernetes.io/name: smithy
+    app.kubernetes.io/part-of: smithy
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: smithy
+  labels:
+    app.kubernetes.io/name: smithy
+    app.kubernetes.io/part-of: smithy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: smithy
+subjects:
+  - kind: ServiceAccount
+    name: smithy
+    namespace: smithy

--- a/deploy/k8s/secret.yaml
+++ b/deploy/k8s/secret.yaml
@@ -1,0 +1,36 @@
+# ============================================================================
+# EDIT ME — these are PLACEHOLDER values. Replace every CHANGE_ME below before
+# applying, OR delete this file and provide your own Secret named "smithy-secrets"
+# (e.g. `kubectl create secret generic smithy-secrets --from-literal=...`).
+# Do NOT commit real credentials.
+#
+# Only the keys matching your VCS_PROVIDER (default forgejo) need real values;
+# the rest can stay empty. Set at least one Claude credential.
+# ============================================================================
+apiVersion: v1
+kind: Secret
+metadata:
+  name: smithy-secrets
+  labels:
+    app.kubernetes.io/name: smithy
+    app.kubernetes.io/part-of: smithy
+type: Opaque
+stringData:
+  # Claude credentials — set at least one.
+  CLAUDE_CODE_OAUTH_TOKEN: "CHANGE_ME"
+  ANTHROPIC_API_KEY: ""
+
+  # Forgejo credentials (default provider).
+  WEBHOOK_SECRET: "CHANGE_ME"
+  SMITHY_FORGEJO_TOKEN: "CHANGE_ME"
+  ARCHITECT_FORGEJO_TOKEN: ""
+
+  # GitLab credentials.
+  GITLAB_WEBHOOK_SECRET: ""
+  SMITHY_GITLAB_TOKEN: ""
+  ARCHITECT_GITLAB_TOKEN: ""
+
+  # GitHub credentials.
+  GITHUB_WEBHOOK_SECRET: ""
+  SMITHY_GITHUB_TOKEN: ""
+  ARCHITECT_GITHUB_TOKEN: ""

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: smithy
+  labels:
+    app.kubernetes.io/name: smithy
+    app.kubernetes.io/part-of: smithy
+    app.kubernetes.io/component: orchestrator
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: smithy
+    app.kubernetes.io/component: orchestrator

--- a/deploy/k8s/serviceaccount.yaml
+++ b/deploy/k8s/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: smithy
+  labels:
+    app.kubernetes.io/name: smithy
+    app.kubernetes.io/part-of: smithy

--- a/openspec/changes/add-kubernetes-deployment/.openspec.yaml
+++ b/openspec/changes/add-kubernetes-deployment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/add-kubernetes-deployment/design.md
+++ b/openspec/changes/add-kubernetes-deployment/design.md
@@ -1,0 +1,95 @@
+## Context
+
+The orchestrator (`orchestrator/backend`, Java 25 / Spring Boot 4 / Gradle 9) runs task work by shelling out to the `docker` CLI. `DockerCli` wraps `ProcessBuilder`; `ContainerService` builds `docker create/start/exec/logs/stop/rm` argument lists and drives the task-container lifecycle; `ContainerSession` is the per-task handle that workflow code holds. Task containers are **long-lived** — created with `smithy-init`, kept running, and repeatedly `exec`'d into. State lives in `/tmp/smithy-state.json` inside the container; there is no database. On startup `WorkflowService.recoverInstances()` lists `smithy.managed=true` containers and rebuilds in-memory state from each container's file.
+
+Deployment today is Docker Compose only (`examples/*/docker-compose.yml`), and the orchestrator container mounts `/var/run/docker.sock`. There is no runtime abstraction — Docker is hardcoded across `service/docker`. Consumers (`WorkflowService`, `DashboardController`, the workflow factories) depend on the concrete `ContainerService` and `ContainerSession`.
+
+We want to run Smithy on Kubernetes: the orchestrator as a Deployment, and each task as a **Pod** launched through the Kubernetes API — no Docker socket, no `docker` CLI in the runtime image path.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Deploy the orchestrator on Kubernetes via a Helm chart (and equivalent kustomize manifests) with config, secrets, RBAC, Service, and optional Ingress.
+- Introduce a `ContainerRuntime` abstraction so the workflow layer is runtime-agnostic; keep Docker as the default, add a Kubernetes implementation that launches task Pods and drives them via the Kubernetes exec/log/API.
+- Preserve the existing long-lived-container + `/tmp/smithy-state.json` + `smithy.managed=true` recovery model unchanged, just backed by Pods.
+- Zero behavior change for existing Docker Compose users (Docker remains default).
+
+**Non-Goals:**
+- Rewriting the state model to use a database, CRDs, or an operator. The Pod-with-state-file model is kept.
+- Autoscaling, multi-tenant isolation policies, NetworkPolicies beyond a sane default, or GitOps packaging (Argo/Flux). Left to operators.
+- Replacing the bundled Forgejo/runner for production; they remain optional dev conveniences.
+- Migrating the Compose examples away from Docker.
+
+## Decisions
+
+### D1: Abstract at `ContainerService`, not at `DockerCli`
+`DockerCli.run(List<String> args)` is inherently Docker-CLI-shaped, so the clean seam is one level up. We extract a `ContainerRuntime` interface capturing the operations `ContainerSession` and the consumers actually use:
+
+```
+createSession(name) -> ContainerSession
+create(name, ContainerConfig)         // package→interface
+exec(name, cmd, env, timeout, stdin) -> ExecResult
+destroy(name)
+fetchLogs(name, tail) / fetchOwnLogs(tail)
+fetchSessionTranscript(name, sessionId)
+copyToContainer / copyFromContainer
+readState / writeState / readStateSafe
+containerExists / isManagedContainer / listManagedContainers
+```
+
+`ContainerSession` is moved to depend on `ContainerRuntime` (constructor takes the interface). The current `ContainerService` becomes `DockerContainerRuntime implements ContainerRuntime` with essentially the same body. Consumers change their injected type from `ContainerService` to `ContainerRuntime` — a mechanical, low-risk edit. The DTOs (`ContainerConfig`, `ContainerState`, `ExecResult`, `ContainerState`) are runtime-neutral and move under `service/runtime/dto` (or stay, with the interface importing them).
+
+_Alternative considered_: implement a `KubernetesCli` that emulates `docker` arg strings behind `DockerCli`. Rejected — brittle string-matching, and it wouldn't remove the `docker` binary assumption.
+
+### D2: Fabric8 Kubernetes client for the Kubernetes runtime
+Use `io.fabric8:kubernetes-client` for `KubernetesContainerRuntime`. It provides in-cluster config auto-detection (ServiceAccount token), typed Pod builders, `pods().withName(x).exec(...)` with stdin/stdout/stderr streams and exit-code listener, log tailing, and file upload/download — a close match to the Docker operations. In-cluster the client authenticates automatically via the mounted ServiceAccount.
+
+_Alternative considered_: official `io.kubernetes:client-java`. More verbose exec/copy ergonomics; Fabric8's `ExecWatch` + `writingOutput`/`redirectingInput` maps more directly onto our synchronous `ExecResult` contract.
+
+### D3: Map Docker concepts → Kubernetes
+- **container create/start** → build and `create` a `Pod` (single container, task image, `smithy-init` command). No Deployment/Job — we need a stable, long-lived, exec-able Pod matching the current model, and `restartPolicy: Never` so a failed init surfaces instead of crash-looping.
+- **`--network forgejo-net`** → Kubernetes cluster networking; task Pods reach the VCS via its Service DNS name. `runtime.network` is unused for Kubernetes; VCS URL comes from config.
+- **`-v cache-pnpm:/path`** → per-cache `PersistentVolumeClaim`s (RWX where the platform supports it) or `emptyDir` when persistence is disabled. `values.yaml` toggles cache persistence and storage class.
+- **labels** → Pod `metadata.labels` (`smithy.managed=true`, `smithy.workflow=<type>`); discovery uses a label selector.
+- **`docker exec`** → Fabric8 `PodResource.redirectingInput().writingOutput(...).writingError(...).withTTY(false).exec(cmd)`, working dir `/workspace` (prefixed via `sh -c 'cd /workspace && …'` since the exec API has no cwd option), env injected by wrapping the command, timeout enforced by awaiting the `ExecWatch` latch.
+- **`docker logs`** → `pods().withName(x).tailingLines(n).getLog()`.
+- **copy files** → write via exec (`sh -c 'cat > path'` with stdin, as today) to avoid tar-based `cp` edge cases; read via `exec cat`. This reuses the exact byte-transfer approach already proven in `ContainerService`.
+- **init wait** → poll for `/tmp/smithy-init-done` / `/tmp/smithy-init-failed` via exec, same as Docker, plus Pod-phase check (`Failed`/`Succeeded` ⇒ abort with logs).
+
+### D4: Runtime selection via config + Spring conditional wiring
+Add a `runtime` block to `orchestrator.yml`:
+```yaml
+runtime:
+  type: ${SMITHY_RUNTIME:docker}      # docker | kubernetes
+  kubernetes:
+    namespace: ${KUBERNETES_NAMESPACE:smithy}
+    task-service-account: ${TASK_SERVICE_ACCOUNT:}
+    task-cpu-request / task-memory-request / limits ...
+    image-pull-secret: ${TASK_IMAGE_PULL_SECRET:}
+```
+`ConfigLoader` exposes a `RuntimeConfig` bean. Wire exactly one `ContainerRuntime` with `@ConditionalOnProperty`-style selection driven by the resolved `runtime.type` (implemented via a `@Bean` factory in a `RuntimeConfiguration` that reads `RuntimeConfig` and constructs the right impl, failing fast on unknown values). Default `docker` keeps Compose users unaffected.
+
+### D5: Deployment packaging — Helm chart primary, kustomize mirror
+`deploy/helm/smithy` is the primary artifact (templated Deployment, Service, ServiceAccount, Role+RoleBinding, ConfigMap, Secret, optional Ingress, optional Forgejo + knowledgebase with PVCs). `deploy/k8s` is a kustomize base equivalent to a default render for non-Helm users. The chart defaults `SMITHY_RUNTIME=kubernetes`. RBAC is a **namespaced Role** (no ClusterRole): `pods`, `pods/log` (get/list/watch/create/delete) and `pods/exec` (create). README + `docs` get a Kubernetes quickstart.
+
+## Risks / Trade-offs
+
+- **[Fabric8 / Java 25 / Spring Boot 4 compatibility]** → Pin a recent Fabric8 (7.x) known to run on JDK 21+; the client is plain and does not depend on Spring. Verify with `./gradlew :backend:compileJava` and a smoke unit test using the mock server if feasible.
+- **[Exec working-directory & env semantics differ from `docker exec -w -e`]** → Wrap commands as `sh -lc 'cd /workspace && exec "$@"'`-style with env exported, and cover with a unit test against the Fabric8 mock server / kind in CI. Risk of shell-quoting bugs; mitigated by reusing the existing single-quote escaping helper.
+- **[Task Pod cannot pull image / no pull secret]** → Surface Pod `Waiting` reason (`ImagePullBackOff`) during init-wait and fail with a clear message; expose `imagePullSecret` in config and chart.
+- **[Ephemeral Pod state on eviction]** → Same failure mode as Docker today (container loss loses `/tmp` state); recovery already tolerates missing/unreadable state (`readStateSafe`). No regression; documented as a known limitation.
+- **[RBAC too broad if misused]** → Ship namespaced Role only; document that the orchestrator and its task Pods should live in a dedicated namespace.
+- **[Socket-mount habit]** → Chart must NOT mount `/var/run/docker.sock`; the Kubernetes runtime never calls `docker`. Guard by keeping the `docker` CLI out of the Kubernetes code path (it stays only in `DockerContainerRuntime`).
+
+## Migration Plan
+
+1. Land the `ContainerRuntime` refactor with Docker as the sole implementation — no behavior change; existing tests + Compose demo stay green.
+2. Add Fabric8 dependency, `KubernetesContainerRuntime`, `RuntimeConfig`, and conditional wiring; default remains `docker`.
+3. Add `deploy/helm/smithy` + `deploy/k8s` + docs.
+4. Validate: `helm template` / `helm lint`, `kubectl apply --dry-run=server -k deploy/k8s`, backend compile + unit tests, and a manual kind/minikube smoke run of a single task Pod.
+5. **Rollback**: set `SMITHY_RUNTIME=docker` (or redeploy the Compose stack). The Kubernetes path is additive and opt-in; reverting is config-only.
+
+## Open Questions
+
+- Cache volumes on Kubernetes: RWX PVC vs per-task `emptyDir`? Default to `emptyDir` (no cross-task cache) unless a storage class is provided — revisit if cache reuse proves important.
+- Should task Pods get their own restricted ServiceAccount (no API access)? Default yes: tasks run under a token-less/`automountServiceAccountToken: false` Pod to avoid granting them cluster access.

--- a/openspec/changes/add-kubernetes-deployment/proposal.md
+++ b/openspec/changes/add-kubernetes-deployment/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Smithy-AI currently runs only as a Docker Compose stack: the orchestrator mounts `/var/run/docker.sock` and shells out to the `docker` CLI to spawn long-lived task containers. This ties every deployment to a single Docker host, blocks horizontal scaling and scheduling, and is an anti-pattern (socket mounting) on managed platforms. To run Smithy on real infrastructure we need first-class Kubernetes support: deploy the orchestrator as a workload, and let it launch task workloads as Pods instead of Docker containers.
+
+## What Changes
+
+- **Add Kubernetes deployment manifests** (a Helm chart under `deploy/helm/smithy` plus plain-manifest/kustomize equivalents under `deploy/k8s`) to run the orchestrator on a cluster: `Deployment`, `Service`, `Ingress`, `ConfigMap`, `Secret`, `ServiceAccount` + RBAC. Optional bundled Forgejo and knowledgebase are toggleable.
+- **Introduce a pluggable container runtime** behind a `ContainerRuntime` interface. The existing Docker-CLI behavior becomes `DockerContainerRuntime`; a new `KubernetesContainerRuntime` launches each task as a Pod and drives it through the Kubernetes API (create Pod, exec, stream logs, copy files, delete) instead of `docker`.
+- **Add a runtime selector** config (`runtime.type: docker|kubernetes`, env `SMITHY_RUNTIME`) so the same image runs unchanged on Docker Compose or Kubernetes.
+- **Grant least-privilege RBAC** for the Kubernetes runtime: a namespaced `Role` allowing `pods`, `pods/exec`, `pods/log` create/get/list/delete, bound to the orchestrator `ServiceAccount`.
+- **Document** the Kubernetes install path in the README / `docs`, mirroring the existing Compose demo.
+- **BREAKING**: none for existing Docker users — Docker stays the default runtime. Kubernetes is opt-in via config.
+
+## Capabilities
+
+### New Capabilities
+- `kubernetes-deployment`: Deploying the orchestrator (and optional dependencies) onto a Kubernetes cluster via Helm/manifests — workload, networking, config, secrets, and RBAC.
+- `container-runtime`: A pluggable task-container runtime abstraction with Docker and Kubernetes implementations, selected by configuration, so tasks run as Docker containers or Kubernetes Pods with identical orchestrator behavior.
+
+### Modified Capabilities
+<!-- No existing OpenSpec specs yet; this is the first change. -->
+
+## Impact
+
+- **Code**: `orchestrator/backend` — new `service/runtime` package (`ContainerRuntime` interface, `DockerContainerRuntime`, `KubernetesContainerRuntime`, Kubernetes client wrapper); `ContainerService`/`ContainerSession` refactored to depend on the interface; new `RuntimeConfig`; Spring conditional wiring. New dependency: Fabric8 `kubernetes-client`.
+- **Config**: new `runtime` block in `orchestrator.yml`; env `SMITHY_RUNTIME`, `KUBERNETES_NAMESPACE`, task Pod resource/label settings.
+- **Deploy**: new `deploy/helm/smithy` chart and `deploy/k8s` manifests; CI image already published to `ghcr.io/smithy-ai/orchestrator`.
+- **Ops**: requires a namespace, ServiceAccount, and RBAC; task Pods scheduled in-cluster reach the VCS Service over cluster networking (replacing `DOCKER_NETWORK`).
+- **Docs**: README + `docs` gain a Kubernetes quickstart.

--- a/openspec/changes/add-kubernetes-deployment/specs/container-runtime/spec.md
+++ b/openspec/changes/add-kubernetes-deployment/specs/container-runtime/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Pluggable container runtime abstraction
+
+The orchestrator SHALL drive task containers through a `ContainerRuntime` interface rather than calling the Docker CLI directly. The interface SHALL expose the operations the workflow layer needs: create a task container, exec a command (with optional stdin, environment, timeout), fetch logs, copy files in and out, read/write task state, list managed containers, check existence, and destroy a container. `ContainerService` and `ContainerSession` SHALL depend only on this interface.
+
+#### Scenario: Workflow code is runtime-agnostic
+
+- **WHEN** a workflow creates a session and execs commands against a task container
+- **THEN** it calls `ContainerRuntime` methods without referencing Docker- or Kubernetes-specific types, and behaves identically regardless of the selected runtime
+
+#### Scenario: Docker behavior preserved as an implementation
+
+- **WHEN** the runtime type is `docker`
+- **THEN** the `DockerContainerRuntime` implementation performs the same `docker create/start/exec/logs/stop/rm` operations the current `ContainerService` performs, with no observable behavior change for existing Docker Compose users
+
+### Requirement: Runtime selection by configuration
+
+The orchestrator SHALL select the active runtime from configuration key `runtime.type` (env `SMITHY_RUNTIME`), accepting `docker` or `kubernetes`, defaulting to `docker`. Exactly one runtime implementation SHALL be wired into the application context at startup.
+
+#### Scenario: Default is docker
+
+- **WHEN** `runtime.type` / `SMITHY_RUNTIME` is unset
+- **THEN** the orchestrator starts with the Docker runtime active
+
+#### Scenario: Kubernetes runtime selected
+
+- **WHEN** `SMITHY_RUNTIME=kubernetes`
+- **THEN** the orchestrator wires `KubernetesContainerRuntime` and no Docker CLI invocation occurs at runtime
+
+#### Scenario: Invalid runtime rejected
+
+- **WHEN** `runtime.type` is set to an unsupported value
+- **THEN** the application fails fast at startup with a clear error message naming the accepted values
+
+### Requirement: Kubernetes task containers run as Pods
+
+When the Kubernetes runtime is active, each task container SHALL be created as a Kubernetes Pod in a configured namespace, running the configured task image with the `smithy-init` entrypoint and the same environment variables (VCS URL/token, clone URL, branch, Claude credentials, git identity, extra repos) the Docker runtime passes. The Pod SHALL carry the label `smithy.managed=true` and a `smithy.workflow=<type>` label so it can be discovered and reconciled.
+
+#### Scenario: Task Pod created and reachable
+
+- **WHEN** a workflow starts a task under the Kubernetes runtime
+- **THEN** a Pod is created in the configured namespace with the task image, the `smithy.managed=true` label, and the task environment, and it can reach the VCS service over in-cluster networking
+
+#### Scenario: Init completion is awaited
+
+- **WHEN** a task Pod is created
+- **THEN** the runtime waits for the init-success marker (`/tmp/smithy-init-done`) via exec, and on the init-failure marker (`/tmp/smithy-init-failed`) or premature Pod termination it raises an error including recent Pod logs
+
+### Requirement: Kubernetes exec, logs, and file transfer
+
+The Kubernetes runtime SHALL implement command execution, log retrieval, and file copy against task Pods using the Kubernetes API (exec/attach and log endpoints), preserving the semantics of the Docker implementation: exec runs in the `/workspace` working directory, supports environment overrides, stdin, and timeouts, and returns stdout, stderr, and an exit code; state is read/written as `/tmp/smithy-state.json` inside the Pod.
+
+#### Scenario: Exec returns captured output and exit code
+
+- **WHEN** a command is exec'd in a task Pod with an environment map and a timeout
+- **THEN** the runtime returns an `ExecResult` with stdout, stderr, and the process exit code, and enforces the timeout
+
+#### Scenario: State round-trips through the Pod
+
+- **WHEN** the orchestrator writes task state and later reads it back
+- **THEN** the state is persisted to `/tmp/smithy-state.json` in the Pod and deserializes to the same `ContainerState`
+
+### Requirement: Managed Pod discovery and cleanup
+
+The Kubernetes runtime SHALL list, identify, and destroy managed task Pods by the `smithy.managed=true` label selector, mirroring the Docker runtime's `listManagedContainers` / `isManagedContainer` / `destroy` behavior so orphaned tasks can be reconciled on startup.
+
+#### Scenario: Orphaned task Pods reconciled
+
+- **WHEN** the orchestrator starts and queries managed containers
+- **THEN** it receives the names of all Pods labeled `smithy.managed=true` in the namespace and can destroy them by deleting the Pod

--- a/openspec/changes/add-kubernetes-deployment/specs/kubernetes-deployment/spec.md
+++ b/openspec/changes/add-kubernetes-deployment/specs/kubernetes-deployment/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Orchestrator deployable via Helm chart
+
+The project SHALL provide a Helm chart (`deploy/helm/smithy`) that deploys the orchestrator onto a Kubernetes cluster as a `Deployment` fronted by a `Service`, using the published `ghcr.io/smithy-ai/orchestrator` image. Image repository/tag, replica count, resource requests/limits, service type, and ingress SHALL be configurable through `values.yaml`. The chart SHALL pass `SMITHY_RUNTIME=kubernetes` by default so tasks run as Pods.
+
+#### Scenario: Fresh install renders valid manifests
+
+- **WHEN** an operator runs `helm install smithy deploy/helm/smithy` with a minimal `values.yaml`
+- **THEN** the chart renders and applies a Deployment, Service, ServiceAccount, ConfigMap, and Secret without error, and the orchestrator Pod reaches Ready
+
+#### Scenario: Runtime defaults to kubernetes
+
+- **WHEN** the chart is installed with default values
+- **THEN** the orchestrator container receives `SMITHY_RUNTIME=kubernetes` and launches task Pods rather than attempting to use a Docker socket
+
+### Requirement: Configuration via ConfigMap and Secret
+
+Non-secret configuration (VCS provider/URLs, runtime type, namespace, task image, knowledgebase settings, bot identities) SHALL be delivered via a `ConfigMap`, and secret values (Claude OAuth token / Anthropic API key, VCS tokens, webhook secret) via a `Secret`. The orchestrator SHALL read these as environment variables matching the existing `orchestrator.yml` placeholders. Secrets SHALL be referenceable from an existing (externally managed) Secret name for users who manage secrets out-of-band.
+
+#### Scenario: Environment mapping matches config placeholders
+
+- **WHEN** the ConfigMap and Secret are mounted as env vars
+- **THEN** the orchestrator resolves `FORGEJO_URL`, `SMITHY_FORGEJO_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `WEBHOOK_SECRET`, `TASK_IMAGE`, and related keys exactly as it does under Docker Compose
+
+#### Scenario: Externally managed secret
+
+- **WHEN** `values.yaml` sets `existingSecret` to a pre-created Secret name
+- **THEN** the chart does not template its own Secret and instead wires the Deployment to the named Secret
+
+### Requirement: Least-privilege RBAC for the task runtime
+
+The chart SHALL create a `ServiceAccount` for the orchestrator and a namespaced `Role` + `RoleBinding` granting only the permissions the Kubernetes runtime needs: `create`, `get`, `list`, `watch`, and `delete` on `pods`, `pods/log`, and `create` on `pods/exec` within the orchestrator's namespace. The orchestrator Deployment SHALL run under this ServiceAccount.
+
+#### Scenario: Runtime can manage task Pods
+
+- **WHEN** the orchestrator, running under its ServiceAccount, creates, execs into, reads logs from, and deletes a task Pod
+- **THEN** all operations succeed within the configured namespace
+
+#### Scenario: No cluster-wide privileges granted
+
+- **WHEN** an operator audits the chart's RBAC
+- **THEN** only a namespaced Role (no ClusterRole) is created, scoped to pod lifecycle, exec, and logs
+
+### Requirement: External access via Ingress
+
+The chart SHALL optionally create an `Ingress` (toggleable, with configurable host, class, TLS, and annotations) exposing the orchestrator's port 8080 so VCS webhooks and the dashboard are reachable from outside the cluster. When ingress is disabled the Service SHALL still allow in-cluster and port-forward access.
+
+#### Scenario: Ingress exposes webhook and dashboard
+
+- **WHEN** ingress is enabled with a host and TLS
+- **THEN** external webhook POSTs and dashboard requests reach the orchestrator Service on port 8080 over the configured host
+
+### Requirement: Optional bundled dependencies
+
+The chart SHALL optionally deploy a Forgejo instance and the knowledgebase MCP server as in-cluster workloads (each toggleable, default off for Forgejo since production users bring their own VCS), with persistent storage for Forgejo data and the knowledgebase vector store via `PersistentVolumeClaim`s. When disabled, the orchestrator SHALL be configured to point at externally provided URLs.
+
+#### Scenario: Knowledgebase enabled with persistence
+
+- **WHEN** `knowledgebase.enabled=true`
+- **THEN** the chart deploys the knowledgebase Deployment, Service, and a PVC for its vector store, and sets `KNOWLEDGEBASE_ENABLED=true` and `KNOWLEDGEBASE_URL` on the orchestrator
+
+#### Scenario: Bring-your-own VCS
+
+- **WHEN** Forgejo is disabled and `vcs.forgejo.url` points to an external instance
+- **THEN** the orchestrator uses the external VCS and no Forgejo workload is created
+
+### Requirement: Plain-manifest install path
+
+In addition to the Helm chart, the project SHALL provide plain Kubernetes manifests (kustomize base under `deploy/k8s`) equivalent to a default chart render, plus documented quickstart steps, so operators who do not use Helm can deploy with `kubectl apply -k`.
+
+#### Scenario: Kustomize apply deploys the orchestrator
+
+- **WHEN** an operator edits the kustomize secret/config inputs and runs `kubectl apply -k deploy/k8s`
+- **THEN** the orchestrator, its Service, ServiceAccount, RBAC, ConfigMap, and Secret are created and the orchestrator becomes Ready

--- a/openspec/changes/add-kubernetes-deployment/tasks.md
+++ b/openspec/changes/add-kubernetes-deployment/tasks.md
@@ -1,0 +1,43 @@
+## 1. Container runtime abstraction (refactor, no behavior change)
+
+- [x] 1.1 Create `service/runtime` package and a `ContainerRuntime` interface exposing the operations `ContainerSession` and consumers use: `createSession`, `create`, `exec`, `destroy`, `fetchLogs`, `fetchOwnLogs`, `fetchSessionTranscript`, `copyToContainer`, `copyFromContainer`, `readState`, `writeState`, `readStateSafe`, `containerExists`, `isManagedContainer`, `listManagedContainers`.
+- [x] 1.2 Move runtime-neutral DTOs (`ContainerConfig`, `ContainerState`, `ExecResult`, `WorkflowType`) so both implementations share them; keep imports compiling.
+- [x] 1.3 Change `ContainerSession` to hold a `ContainerRuntime` instead of the concrete `ContainerService`; adjust its delegating calls.
+- [x] 1.4 Rename/convert the existing `ContainerService` into `DockerContainerRuntime implements ContainerRuntime` (body unchanged; keep `DockerCli` as its private dependency). Annotate so it is only wired when `runtime.type=docker`.
+- [x] 1.5 Update consumers (`WorkflowService`, `DashboardController`, `SmithyWorkflowFactory`, `ArchitectReviewFactory`, `ArchitectLearnFactory`, and any `ContainerService`/`ContainerSession` importers) to inject `ContainerRuntime`.
+- [x] 1.6 Compile backend (`./gradlew :backend:compileJava`) and run existing tests to confirm no behavior change with the Docker runtime.
+
+## 2. Runtime configuration & selection
+
+- [x] 2.1 Add a `runtime` block to `orchestrator.yml` (`type: ${SMITHY_RUNTIME:docker}`, plus a `kubernetes` sub-block: namespace, task service account, cpu/memory requests+limits, image-pull-secret, cache-persistence toggle).
+- [x] 2.2 Add `RuntimeConfig` record + nested `KubernetesRuntimeConfig`; expose a `RuntimeConfig` bean from `ConfigLoader` and add it to `SmithyConfig`.
+- [x] 2.3 Add a `RuntimeConfiguration` class that constructs exactly one `ContainerRuntime` bean based on `runtime.type`, failing fast with a clear message on unknown values (`docker` default).
+
+## 3. Kubernetes runtime implementation
+
+- [x] 3.1 Add `io.fabric8:kubernetes-client` (pin a JDK 21+ compatible 7.x) to `backend/build.gradle.kts`; provide an in-cluster `KubernetesClient` bean (only when `runtime.type=kubernetes`).
+- [x] 3.2 Implement `KubernetesContainerRuntime implements ContainerRuntime`: `create` builds and creates a Pod (task image, `smithy-init`, `restartPolicy: Never`, labels `smithy.managed=true` / `smithy.workflow=<type>`, env from `ContainerConfig`, `automountServiceAccountToken: false`, optional imagePullSecret, cache volumes as PVC/emptyDir per config).
+- [x] 3.3 Implement `exec` via Fabric8 `ExecWatch` (working dir `/workspace`, env injection, stdin, timeout via latch) returning `ExecResult` with stdout/stderr/exit code.
+- [x] 3.4 Implement `fetchLogs`/`fetchOwnLogs` via pod log tailing; implement `copyToContainer`/`copyFromContainer` and `readState`/`writeState`/`readStateSafe` via `exec cat`/`exec 'cat > path'` reusing the existing byte-transfer + quoting approach.
+- [x] 3.5 Implement `containerExists`, `isManagedContainer`, `listManagedContainers`, `destroy`, and init-wait (`/tmp/smithy-init-done`/`/tmp/smithy-init-failed` polling + Pod-phase/`ImagePullBackOff` detection with recent logs on failure).
+- [x] 3.6 Add a unit test for `KubernetesContainerRuntime` using the Fabric8 mock server (Pod create, list-by-label, destroy; exec/log where mock supports it).
+
+## 4. Helm chart (`deploy/helm/smithy`)
+
+- [x] 4.1 Scaffold chart (`Chart.yaml`, `values.yaml`, `_helpers.tpl`) with image repo/tag defaulting to `ghcr.io/smithy-ai/orchestrator`, replicas, resources, and `SMITHY_RUNTIME=kubernetes` default.
+- [x] 4.2 Template `Deployment` (env from ConfigMap + Secret, ServiceAccount, probes on `/api/health`, port 8080) and `Service`.
+- [x] 4.3 Template `ServiceAccount` + namespaced `Role` + `RoleBinding` granting `pods`/`pods/log` (get/list/watch/create/delete) and `pods/exec` (create) only.
+- [x] 4.4 Template `ConfigMap` (non-secret config: VCS URLs/provider, runtime, namespace, task image, knowledgebase, bots) and `Secret` (Claude/VCS tokens, webhook secret) with `existingSecret` override support.
+- [x] 4.5 Template optional `Ingress` (host, class, TLS, annotations) exposing port 8080.
+- [x] 4.6 Template optional Forgejo (default off) and knowledgebase (default off) workloads + Services + PVCs, and wire the orchestrator to their in-cluster URLs when enabled or external URLs when disabled.
+- [x] 4.7 `helm lint` and `helm template` render cleanly with default and knowledgebase-enabled values.
+
+## 5. Plain manifests (`deploy/k8s`) & validation
+
+- [x] 5.1 Provide a kustomize base equivalent to a default chart render (namespace, ServiceAccount, RBAC, ConfigMap, Secret placeholder, Deployment, Service).
+- [x] 5.2 Validate with `kubectl apply --dry-run=server -k deploy/k8s` (or client dry-run where no cluster is available).
+
+## 6. Docs & smoke test
+
+- [x] 6.1 Add a Kubernetes quickstart to `README.md` and `docs` (install via Helm and via kustomize, required secrets, runtime selection, RBAC notes).
+- [ ] 6.2 Smoke-test on kind/minikube: install the chart, trigger one task, confirm a `smithy.managed=true` task Pod is created, exec'd, and cleaned up; capture and document any gaps.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/orchestrator/backend/build.gradle.kts
+++ b/orchestrator/backend/build.gradle.kts
@@ -28,7 +28,11 @@ dependencies {
     implementation("com.github.victools:jsonschema-generator:4.38.0")
     implementation("com.github.victools:jsonschema-module-jackson:4.38.0")
 
+    // Kubernetes task runtime (used when runtime.type=kubernetes)
+    implementation("io.fabric8:kubernetes-client:7.3.1")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("io.fabric8:kubernetes-server-mock:7.3.1")
 }
 
 spotless {

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/ConfigLoader.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/ConfigLoader.java
@@ -33,6 +33,11 @@ public class ConfigLoader {
     }
 
     @Bean
+    public RuntimeConfig runtimeConfig() {
+        return config.runtime() != null ? config.runtime() : RuntimeConfig.defaults();
+    }
+
+    @Bean
     public DockerConfig dockerConfig() {
         return config.docker();
     }

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/RuntimeConfig.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/RuntimeConfig.java
@@ -1,0 +1,75 @@
+package dev.smithyai.orchestrator.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Selects and configures the task-container runtime. {@code type} chooses the backend
+ * ({@code docker} or {@code kubernetes}); the {@code kubernetes} block carries Pod-scheduling
+ * settings used only by the Kubernetes runtime.
+ */
+public record RuntimeConfig(String type, KubernetesRuntimeConfig kubernetes) {
+    public enum Type {
+        DOCKER,
+        KUBERNETES,
+    }
+
+    /** Default configuration (Docker runtime) used when the config omits a {@code runtime} block. */
+    public static RuntimeConfig defaults() {
+        return new RuntimeConfig("docker", KubernetesRuntimeConfig.defaults());
+    }
+
+    public RuntimeConfig {
+        if (kubernetes == null) kubernetes = KubernetesRuntimeConfig.defaults();
+    }
+
+    /** Parse {@code type} into the enum, failing fast with a clear message on unknown values. */
+    public Type resolvedType() {
+        String t = type == null || type.isBlank() ? "docker" : type.strip().toLowerCase();
+        return switch (t) {
+            case "docker" -> Type.DOCKER;
+            case "kubernetes", "k8s" -> Type.KUBERNETES;
+            default -> throw new IllegalArgumentException(
+                "Unknown runtime.type '" + type + "'. Accepted values: docker, kubernetes"
+            );
+        };
+    }
+
+    public KubernetesRuntimeConfig resolvedKubernetes() {
+        return kubernetes != null ? kubernetes : KubernetesRuntimeConfig.defaults();
+    }
+
+    /**
+     * Kubernetes runtime settings. Blank optional strings are treated as unset.
+     */
+    public record KubernetesRuntimeConfig(
+        String namespace,
+        @JsonProperty("task-service-account") String taskServiceAccount,
+        @JsonProperty("image-pull-secret") String imagePullSecret,
+        @JsonProperty("task-cpu-request") String taskCpuRequest,
+        @JsonProperty("task-memory-request") String taskMemoryRequest,
+        @JsonProperty("task-cpu-limit") String taskCpuLimit,
+        @JsonProperty("task-memory-limit") String taskMemoryLimit,
+        @JsonProperty("cache-persistence") boolean cachePersistence,
+        @JsonProperty("storage-class") String storageClass
+    ) {
+        public static KubernetesRuntimeConfig defaults() {
+            return new KubernetesRuntimeConfig("smithy", null, null, "250m", "512Mi", null, null, false, null);
+        }
+
+        public String resolvedNamespace() {
+            return namespace == null || namespace.isBlank() ? "smithy" : namespace.strip();
+        }
+
+        public boolean hasServiceAccount() {
+            return taskServiceAccount != null && !taskServiceAccount.isBlank();
+        }
+
+        public boolean hasImagePullSecret() {
+            return imagePullSecret != null && !imagePullSecret.isBlank();
+        }
+
+        public boolean hasStorageClass() {
+            return storageClass != null && !storageClass.isBlank();
+        }
+    }
+}

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/RuntimeConfiguration.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/RuntimeConfiguration.java
@@ -1,0 +1,50 @@
+package dev.smithyai.orchestrator.config;
+
+import dev.smithyai.orchestrator.service.docker.ContainerRuntime;
+import dev.smithyai.orchestrator.service.docker.DockerCli;
+import dev.smithyai.orchestrator.service.docker.DockerContainerRuntime;
+import dev.smithyai.orchestrator.service.docker.KubernetesContainerRuntime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires exactly one {@link ContainerRuntime} into the application context based on
+ * {@code runtime.type}. The unused implementation is never instantiated, so the Kubernetes client
+ * is only created when {@code runtime.type=kubernetes} and the Docker CLI is only required for the
+ * Docker runtime.
+ */
+@Slf4j
+@Configuration
+public class RuntimeConfiguration {
+
+    @Bean
+    public ContainerRuntime containerRuntime(
+        RuntimeConfig runtimeConfig,
+        DockerConfig dockerConfig,
+        ClaudeConfig claudeConfig,
+        VcsProviderConfig vcsConfig,
+        BotConfig botConfig,
+        ObjectProvider<DockerCli> dockerCli
+    ) {
+        var type = runtimeConfig.resolvedType();
+        log.info("Selecting container runtime: {}", type);
+        return switch (type) {
+            case DOCKER -> new DockerContainerRuntime(
+                dockerConfig,
+                claudeConfig,
+                vcsConfig,
+                botConfig,
+                dockerCli.getObject()
+            );
+            case KUBERNETES -> new KubernetesContainerRuntime(
+                runtimeConfig.resolvedKubernetes(),
+                dockerConfig,
+                claudeConfig,
+                vcsConfig,
+                botConfig
+            );
+        };
+    }
+}

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/SmithyConfig.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/SmithyConfig.java
@@ -1,6 +1,7 @@
 package dev.smithyai.orchestrator.config;
 
 public record SmithyConfig(
+    RuntimeConfig runtime,
     DockerConfig docker,
     ClaudeConfig claude,
     VcsProviderConfig vcs,

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/ContainerRuntime.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/ContainerRuntime.java
@@ -1,0 +1,77 @@
+package dev.smithyai.orchestrator.service.docker;
+
+import dev.smithyai.orchestrator.service.docker.dto.ContainerConfig;
+import dev.smithyai.orchestrator.service.docker.dto.ContainerState;
+import dev.smithyai.orchestrator.service.docker.dto.ExecResult;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Abstraction over the task-container backend. Implementations drive the lifecycle of long-lived
+ * task containers the orchestrator execs into repeatedly. {@link DockerContainerRuntime} shells out
+ * to the {@code docker} CLI; {@link dev.smithyai.orchestrator.service.docker.KubernetesContainerRuntime}
+ * launches each task as a Kubernetes Pod.
+ *
+ * <p>Workflow code depends only on this interface (and on {@link ContainerSession}), so the same
+ * orchestrator image runs unchanged on Docker Compose or Kubernetes based on {@code runtime.type}.
+ */
+public interface ContainerRuntime {
+    // ── Sessions ─────────────────────────────────────────────
+
+    /** Create a per-task session handle bound to this runtime. */
+    ContainerSession createSession(String name);
+
+    // ── Lifecycle ────────────────────────────────────────────
+
+    /** Create and start the task container/Pod and block until its init completes. */
+    void create(String name, ContainerConfig init);
+
+    /** Stop and remove the task container/Pod. */
+    void destroy(String name);
+
+    /** True if a container/Pod with this name exists. */
+    boolean containerExists(String name);
+
+    // ── Discovery ────────────────────────────────────────────
+
+    /** Names of running managed task containers/Pods (label {@code smithy.managed=true}). */
+    List<String> listManagedContainers();
+
+    /** True if a managed container/Pod (running or not) with this name exists. */
+    boolean isManagedContainer(String name);
+
+    // ── Exec ─────────────────────────────────────────────────
+
+    /**
+     * Run a command inside the task container/Pod in the {@code /workspace} working directory.
+     *
+     * @param environment optional extra environment for the command
+     * @param timeout     optional timeout; runtime default applied when null
+     * @param stdinInput  optional stdin piped to the process
+     */
+    ExecResult exec(String name, List<String> command, Map<String, String> environment, Duration timeout, String stdinInput);
+
+    // ── Logs ─────────────────────────────────────────────────
+
+    String fetchLogs(String name, int tailLines);
+
+    String fetchOwnLogs(int tailLines);
+
+    String fetchSessionTranscript(String name, String sessionId);
+
+    // ── File transfer ────────────────────────────────────────
+
+    byte[] copyFromContainer(String name, String path);
+
+    void copyToContainer(String name, String destDir, byte[] data, String filename);
+
+    // ── State ────────────────────────────────────────────────
+
+    ContainerState readState(String name);
+
+    void writeState(String name, ContainerState state);
+
+    Optional<ContainerState> readStateSafe(String name);
+}

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/ContainerSession.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/ContainerSession.java
@@ -13,14 +13,14 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ContainerSession {
 
-    private final ContainerService service;
+    private final ContainerRuntime service;
 
     @Getter
     private final String containerName;
 
     private ContainerState cachedState;
 
-    public ContainerSession(String containerName, ContainerService service) {
+    public ContainerSession(String containerName, ContainerRuntime service) {
         this.containerName = containerName;
         this.service = service;
     }

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/DockerContainerRuntime.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/DockerContainerRuntime.java
@@ -14,11 +14,17 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
+/**
+ * {@link ContainerRuntime} backed by the {@code docker} CLI. Preserves the original behavior of the
+ * orchestrator's Docker Compose deployment: task work runs in long-lived containers created with
+ * {@code docker create}/{@code start} and driven via {@code docker exec}/{@code logs}/{@code rm}.
+ *
+ * <p>Wired only when {@code runtime.type=docker} (see
+ * {@link dev.smithyai.orchestrator.config.RuntimeConfiguration}).
+ */
 @Slf4j
-@Component
-public class ContainerService {
+public class DockerContainerRuntime implements ContainerRuntime {
 
     private static final String STATE_PATH = "/tmp/smithy-state.json";
     static final ObjectMapper MAPPER = new ObjectMapper()
@@ -38,7 +44,7 @@ public class ContainerService {
     private final String gitAuthUser;
     private final String defaultGitEmail;
 
-    public ContainerService(
+    public DockerContainerRuntime(
         DockerConfig dockerConfig,
         ClaudeConfig claudeConfig,
         VcsProviderConfig vcsConfig,
@@ -58,15 +64,18 @@ public class ContainerService {
 
     // ── Public API ───────────────────────────────────────────
 
+    @Override
     public ContainerSession createSession(String name) {
         return new ContainerSession(name, this);
     }
 
+    @Override
     public boolean containerExists(String containerName) {
         var result = docker.run(List.of("inspect", containerName));
         return result.exitCode() == 0;
     }
 
+    @Override
     public List<String> listManagedContainers() {
         var result = docker.run(List.of("ps", "--filter", "label=smithy.managed=true", "--format", "{{.Names}}"));
         if (result.exitCode() != 0) {
@@ -81,6 +90,7 @@ public class ContainerService {
             .toList();
     }
 
+    @Override
     public boolean isManagedContainer(String containerName) {
         var result = docker.run(List.of("ps", "-a", "--filter", "label=smithy.managed=true", "--format", "{{.Names}}"));
         if (result.exitCode() != 0) {
@@ -90,6 +100,7 @@ public class ContainerService {
         return result.stdout().lines().map(String::strip).anyMatch(containerName::equals);
     }
 
+    @Override
     public Optional<ContainerState> readStateSafe(String containerName) {
         try {
             byte[] data = copyFromContainer(containerName, STATE_PATH);
@@ -102,7 +113,8 @@ public class ContainerService {
 
     // ── Container lifecycle ──────────────────────────────────
 
-    void create(String name, ContainerConfig init) {
+    @Override
+    public void create(String name, ContainerConfig init) {
         var args = new ArrayList<String>();
         args.add("create");
         args.add("--name");
@@ -222,6 +234,7 @@ public class ContainerService {
         log.warn("Container {} init did not complete within {}s — proceeding anyway", name, INIT_TIMEOUT_SECONDS);
     }
 
+    @Override
     public String fetchLogs(String name, int tailLines) {
         var result = docker.run(List.of("logs", "--tail", String.valueOf(tailLines), name));
         String logs = result.stdout();
@@ -231,6 +244,7 @@ public class ContainerService {
         return logs;
     }
 
+    @Override
     public String fetchOwnLogs(int tailLines) {
         String selfId = System.getenv("HOSTNAME");
         if (selfId == null || selfId.isBlank()) {
@@ -243,6 +257,7 @@ public class ContainerService {
      * Reads the Claude Code session transcript (JSONL) for a given session id.
      * Requires the container to be running, since it shells in to read the file.
      */
+    @Override
     public String fetchSessionTranscript(String containerName, String sessionId) {
         var result = docker.run(
             List.of(
@@ -256,7 +271,8 @@ public class ContainerService {
         return result.stdout();
     }
 
-    void destroy(String containerName) {
+    @Override
+    public void destroy(String containerName) {
         docker.run(List.of("stop", containerName));
         docker.run(List.of("rm", "-f", containerName));
         log.info("Destroyed container {}", containerName);
@@ -264,7 +280,8 @@ public class ContainerService {
 
     // ── Exec ─────────────────────────────────────────────────
 
-    ExecResult exec(
+    @Override
+    public ExecResult exec(
         String containerName,
         List<String> command,
         Map<String, String> environment,
@@ -297,7 +314,8 @@ public class ContainerService {
 
     // ── State ────────────────────────────────────────────────
 
-    ContainerState readState(String containerName) {
+    @Override
+    public ContainerState readState(String containerName) {
         try {
             byte[] data = copyFromContainer(containerName, STATE_PATH);
             return MAPPER.readValue(data, ContainerState.class);
@@ -306,7 +324,8 @@ public class ContainerService {
         }
     }
 
-    void writeState(String containerName, ContainerState state) {
+    @Override
+    public void writeState(String containerName, ContainerState state) {
         try {
             byte[] data = MAPPER.writeValueAsBytes(state);
             copyToContainer(containerName, "/tmp", data, "smithy-state.json");
@@ -317,11 +336,13 @@ public class ContainerService {
 
     // ── File transfer ────────────────────────────────────────
 
-    byte[] copyFromContainer(String containerName, String path) {
+    @Override
+    public byte[] copyFromContainer(String containerName, String path) {
         return docker.runForBytes(List.of("exec", containerName, "cat", path), Duration.ofSeconds(30));
     }
 
-    void copyToContainer(String containerName, String destDir, byte[] data, String filename) {
+    @Override
+    public void copyToContainer(String containerName, String destDir, byte[] data, String filename) {
         // Shell-quote the path to prevent injection
         String safePath = destDir + "/" + filename;
         var result = docker.run(

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/KubernetesContainerRuntime.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/KubernetesContainerRuntime.java
@@ -1,0 +1,533 @@
+package dev.smithyai.orchestrator.service.docker;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dev.smithyai.orchestrator.config.BotConfig;
+import dev.smithyai.orchestrator.config.ClaudeConfig;
+import dev.smithyai.orchestrator.config.DockerConfig;
+import dev.smithyai.orchestrator.config.RuntimeConfig.KubernetesRuntimeConfig;
+import dev.smithyai.orchestrator.config.VcsProviderConfig;
+import dev.smithyai.orchestrator.service.docker.dto.ContainerConfig;
+import dev.smithyai.orchestrator.service.docker.dto.ContainerState;
+import dev.smithyai.orchestrator.service.docker.dto.ExecResult;
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.dsl.ExecWatch;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link ContainerRuntime} that runs each task as a Kubernetes Pod, driving it through the
+ * Kubernetes API instead of the {@code docker} CLI. Task Pods are long-lived (running
+ * {@code smithy-init}, {@code restartPolicy: Never}) and exec'd into repeatedly, mirroring the
+ * Docker runtime's model; state lives in {@code /tmp/smithy-state.json} inside the Pod.
+ *
+ * <p>Wired only when {@code runtime.type=kubernetes} (see
+ * {@link dev.smithyai.orchestrator.config.RuntimeConfiguration}). The client authenticates via the
+ * mounted ServiceAccount when running in-cluster.
+ */
+@Slf4j
+public class KubernetesContainerRuntime implements ContainerRuntime, AutoCloseable {
+
+    private static final String STATE_PATH = "/tmp/smithy-state.json";
+    private static final String MANAGED_LABEL = "smithy.managed";
+    private static final String WORKFLOW_LABEL = "smithy.workflow";
+    private static final String TASK_CONTAINER = "task";
+    private static final String WORKDIR = "/workspace";
+    private static final Duration DEFAULT_EXEC_TIMEOUT = Duration.ofSeconds(30);
+
+    private static final int INIT_TIMEOUT_SECONDS = 300;
+    private static final int INIT_POLL_INTERVAL_MS = 1000;
+    private static final int POD_START_TIMEOUT_SECONDS = 120;
+
+    static final ObjectMapper MAPPER = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    private final KubernetesClient client;
+    private final String namespace;
+    private final KubernetesRuntimeConfig k8s;
+    private final String taskImage;
+    private final String vcsUrl;
+    private final String vcsToken;
+    private final String claudeOauthToken;
+    private final String claudeApiKey;
+    private final String gitAuthUser;
+    private final String defaultGitEmail;
+
+    public KubernetesContainerRuntime(
+        KubernetesRuntimeConfig k8sConfig,
+        DockerConfig dockerConfig,
+        ClaudeConfig claudeConfig,
+        VcsProviderConfig vcsConfig,
+        BotConfig botConfig
+    ) {
+        this(new KubernetesClientBuilder().build(), k8sConfig, dockerConfig, claudeConfig, vcsConfig, botConfig);
+    }
+
+    // Package-visible for tests (Fabric8 mock server injects a client).
+    KubernetesContainerRuntime(
+        KubernetesClient client,
+        KubernetesRuntimeConfig k8sConfig,
+        DockerConfig dockerConfig,
+        ClaudeConfig claudeConfig,
+        VcsProviderConfig vcsConfig,
+        BotConfig botConfig
+    ) {
+        this.client = client;
+        this.k8s = k8sConfig;
+        this.namespace = k8sConfig.resolvedNamespace();
+        this.taskImage = dockerConfig.taskImage();
+        this.vcsUrl = vcsConfig.resolvedUrl();
+        this.vcsToken = vcsConfig.smithyToken();
+        this.claudeOauthToken = claudeConfig.oauthToken();
+        this.claudeApiKey = claudeConfig.apiKey();
+        this.gitAuthUser = vcsConfig.gitAuthUser();
+        this.defaultGitEmail = botConfig.resolvedSmithyEmail();
+        log.info("Kubernetes runtime active (namespace={}, taskImage={})", namespace, taskImage);
+    }
+
+    // ── Public API ───────────────────────────────────────────
+
+    @Override
+    public ContainerSession createSession(String name) {
+        return new ContainerSession(name, this);
+    }
+
+    @Override
+    public boolean containerExists(String name) {
+        return pod(name).get() != null;
+    }
+
+    @Override
+    public List<String> listManagedContainers() {
+        return client
+            .pods()
+            .inNamespace(namespace)
+            .withLabel(MANAGED_LABEL, "true")
+            .list()
+            .getItems()
+            .stream()
+            .filter(p -> "Running".equals(phase(p)))
+            .map(p -> p.getMetadata().getName())
+            .toList();
+    }
+
+    @Override
+    public boolean isManagedContainer(String name) {
+        Pod p = pod(name).get();
+        return p != null && p.getMetadata().getLabels() != null && "true".equals(p.getMetadata().getLabels().get(MANAGED_LABEL));
+    }
+
+    @Override
+    public Optional<ContainerState> readStateSafe(String name) {
+        try {
+            byte[] data = copyFromContainer(name, STATE_PATH);
+            return Optional.of(MAPPER.readValue(data, ContainerState.class));
+        } catch (Exception e) {
+            log.warn("Failed to read state from {}: {}", name, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    // ── Pod lifecycle ────────────────────────────────────────
+
+    @Override
+    public void create(String name, ContainerConfig init) {
+        Pod pod = buildPod(name, init);
+        try {
+            client.pods().inNamespace(namespace).resource(pod).create();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create task Pod " + name + ": " + e.getMessage(), e);
+        }
+        log.info("Created Pod {}, waiting for it to start...", name);
+        waitForRunning(name);
+        log.info("Pod {} running, waiting for init...", name);
+        waitForInit(name);
+    }
+
+    Pod buildPod(String name, ContainerConfig init) {
+        List<EnvVar> env = buildEnv(init);
+        List<Volume> volumes = new ArrayList<>();
+        List<VolumeMount> mounts = new ArrayList<>();
+        if (init.cacheVolumes() != null) {
+            init
+                .cacheVolumes()
+                .forEach((vol, path) -> {
+                    String volName = sanitizeVolumeName(vol);
+                    volumes.add(new VolumeBuilder().withName(volName).withNewEmptyDir().endEmptyDir().build());
+                    mounts.add(new VolumeMountBuilder().withName(volName).withMountPath(path).build());
+                });
+        }
+
+        var labels = new LinkedHashMap<String, String>();
+        labels.put(MANAGED_LABEL, "true");
+        if (init.workflowType() != null) {
+            labels.put(WORKFLOW_LABEL, init.workflowType().value());
+        }
+
+        var container = new PodBuilder()
+            .withNewMetadata()
+            .withName(name)
+            .withNamespace(namespace)
+            .withLabels(labels)
+            .endMetadata()
+            .withNewSpec()
+            .withRestartPolicy("Never")
+            .withAutomountServiceAccountToken(false)
+            .withVolumes(volumes)
+            .addNewContainer()
+            .withName(TASK_CONTAINER)
+            .withImage(taskImage)
+            .withCommand("smithy-init")
+            .withEnv(env)
+            .withVolumeMounts(mounts)
+            .withNewResources()
+            .withRequests(resourceMap(k8s.taskCpuRequest(), k8s.taskMemoryRequest()))
+            .withLimits(resourceMap(k8s.taskCpuLimit(), k8s.taskMemoryLimit()))
+            .endResources()
+            .endContainer()
+            .endSpec();
+
+        if (k8s.hasServiceAccount()) {
+            container.editSpec().withServiceAccountName(k8s.taskServiceAccount()).endSpec();
+        }
+        if (k8s.hasImagePullSecret()) {
+            container.editSpec().withImagePullSecrets(new LocalObjectReference(k8s.imagePullSecret())).endSpec();
+        }
+        return container.build();
+    }
+
+    private List<EnvVar> buildEnv(ContainerConfig init) {
+        var env = new ArrayList<EnvVar>();
+        if (claudeOauthToken != null && !claudeOauthToken.isBlank()) {
+            env.add(envVar("CLAUDE_CODE_OAUTH_TOKEN", claudeOauthToken));
+        }
+        if (claudeApiKey != null && !claudeApiKey.isBlank()) {
+            env.add(envVar("ANTHROPIC_API_KEY", claudeApiKey));
+        }
+        env.add(envVar("VCS_URL", vcsUrl));
+        env.add(envVar("VCS_TOKEN", init.vcsToken() != null ? init.vcsToken() : vcsToken));
+        env.add(envVar("CLONE_URL", init.cloneUrl()));
+        env.add(envVar("BRANCH", init.branch()));
+        env.add(envVar("SOURCE_BRANCH", init.sourceBranch() != null ? init.sourceBranch() : ""));
+        env.add(envVar("GIT_EMAIL", init.gitEmail() != null ? init.gitEmail() : defaultGitEmail));
+        env.add(envVar("GIT_USERNAME", init.gitUsername() != null ? init.gitUsername() : "Agent Smithy"));
+        env.add(envVar("GIT_AUTH_USER", gitAuthUser));
+
+        String extraReposJson = "";
+        if (init.extraRepos() != null && !init.extraRepos().isEmpty()) {
+            try {
+                var repoLists = init
+                    .extraRepos()
+                    .stream()
+                    .map(r -> List.of(r.cloneUrl(), r.path(), r.branch()))
+                    .toList();
+                extraReposJson = MAPPER.writeValueAsString(repoLists);
+            } catch (Exception e) {
+                log.warn("Failed to serialize extra repos", e);
+            }
+        }
+        env.add(envVar("EXTRA_REPOS", extraReposJson));
+        return env;
+    }
+
+    private void waitForRunning(String name) {
+        long deadline = System.currentTimeMillis() + POD_START_TIMEOUT_SECONDS * 1000L;
+        while (System.currentTimeMillis() < deadline) {
+            Pod p = pod(name).get();
+            if (p == null) {
+                sleep();
+                continue;
+            }
+            String phase = phase(p);
+            if ("Running".equals(phase)) {
+                return;
+            }
+            if ("Failed".equals(phase) || "Succeeded".equals(phase)) {
+                throw new RuntimeException(
+                    "Pod " + name + " terminated during startup (phase=" + phase + "). Logs:\n" + fetchLogsSafe(name, 50)
+                );
+            }
+            String pullError = imagePullError(p);
+            if (pullError != null) {
+                throw new RuntimeException("Pod " + name + " cannot start: " + pullError);
+            }
+            sleep();
+        }
+        throw new RuntimeException("Pod " + name + " did not reach Running within " + POD_START_TIMEOUT_SECONDS + "s");
+    }
+
+    private void waitForInit(String name) {
+        long deadline = System.currentTimeMillis() + INIT_TIMEOUT_SECONDS * 1000L;
+        while (System.currentTimeMillis() < deadline) {
+            if (markerExists(name, "/tmp/smithy-init-done")) {
+                log.info("Pod {} init completed successfully", name);
+                return;
+            }
+            if (markerExists(name, "/tmp/smithy-init-failed")) {
+                throw new RuntimeException("Pod " + name + " init failed. Logs:\n" + fetchLogsSafe(name, 50));
+            }
+            Pod p = pod(name).get();
+            String phase = p == null ? null : phase(p);
+            if (p == null || "Failed".equals(phase) || "Succeeded".equals(phase)) {
+                throw new RuntimeException(
+                    "Pod " + name + " stopped during init (phase=" + phase + "). Logs:\n" + fetchLogsSafe(name, 50)
+                );
+            }
+            sleep();
+        }
+        log.warn("Pod {} init did not complete within {}s — proceeding anyway", name, INIT_TIMEOUT_SECONDS);
+    }
+
+    private boolean markerExists(String name, String path) {
+        try {
+            // Runs as: test -f <path>; exit 0 when present.
+            ExecResult r = exec(name, List.of("test", "-f", path), null, Duration.ofSeconds(15), null);
+            return r.exitCode() == 0;
+        } catch (Exception e) {
+            // Pod may not be exec-ready yet; treat as "not there yet".
+            return false;
+        }
+    }
+
+    @Override
+    public void destroy(String name) {
+        try {
+            pod(name).withGracePeriod(0).delete();
+            log.info("Destroyed Pod {}", name);
+        } catch (Exception e) {
+            log.warn("Failed to destroy Pod {}: {}", name, e.getMessage());
+        }
+    }
+
+    // ── Exec ─────────────────────────────────────────────────
+
+    @Override
+    public ExecResult exec(String name, List<String> command, Map<String, String> environment, Duration timeout, String stdinInput) {
+        byte[] stdin = stdinInput != null ? stdinInput.getBytes(StandardCharsets.UTF_8) : null;
+        Capture c = execCapture(name, command, environment, timeout, stdin);
+        return new ExecResult(c.exitCode, new String(c.stdout, StandardCharsets.UTF_8), c.stderr);
+    }
+
+    /**
+     * Executes a command in the task container in {@code /workspace} with optional env and stdin,
+     * capturing raw stdout bytes. The command list is passed verbatim as argv (no shell parsing of
+     * its tokens): {@code sh -c 'cd /workspace && exec env "$@"' _ K=V ... cmd arg...}.
+     */
+    private Capture execCapture(String name, List<String> command, Map<String, String> environment, Duration timeout, byte[] stdin) {
+        var argv = new ArrayList<String>();
+        argv.add("sh");
+        argv.add("-c");
+        argv.add("cd " + WORKDIR + " && exec env \"$@\"");
+        argv.add("smithy-exec"); // $0 placeholder
+        if (environment != null) {
+            environment.forEach((k, v) -> argv.add(k + "=" + v));
+        }
+        argv.addAll(command);
+
+        Duration effective = timeout != null ? timeout : DEFAULT_EXEC_TIMEOUT;
+        var out = new ByteArrayOutputStream();
+        var err = new ByteArrayOutputStream();
+        var pod = pod(name).inContainer(TASK_CONTAINER);
+
+        ExecWatch watch = null;
+        try {
+            if (stdin != null) {
+                watch = pod.redirectingInput().writingOutput(out).writingError(err).exec(argv.toArray(String[]::new));
+                try (OutputStream os = watch.getInput()) {
+                    os.write(stdin);
+                }
+            } else {
+                watch = pod.writingOutput(out).writingError(err).exec(argv.toArray(String[]::new));
+            }
+            Integer code = watch.exitCode().get(effective.toMillis(), TimeUnit.MILLISECONDS);
+            return new Capture(code != null ? code : -1, out.toByteArray(), err.toString(StandardCharsets.UTF_8));
+        } catch (TimeoutException e) {
+            return new Capture(124, out.toByteArray(), "Timed out after " + effective);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return new Capture(130, out.toByteArray(), "Interrupted");
+        } catch (Exception e) {
+            return new Capture(1, out.toByteArray(), "exec failed: " + e.getMessage());
+        } finally {
+            if (watch != null) {
+                watch.close();
+            }
+        }
+    }
+
+    private record Capture(int exitCode, byte[] stdout, String stderr) {}
+
+    // ── Logs ─────────────────────────────────────────────────
+
+    @Override
+    public String fetchLogs(String name, int tailLines) {
+        try {
+            return pod(name).tailingLines(tailLines).getLog();
+        } catch (Exception e) {
+            return "Failed to fetch logs for " + name + ": " + e.getMessage();
+        }
+    }
+
+    private String fetchLogsSafe(String name, int tailLines) {
+        return fetchLogs(name, tailLines);
+    }
+
+    @Override
+    public String fetchOwnLogs(int tailLines) {
+        String selfId = System.getenv("HOSTNAME");
+        if (selfId == null || selfId.isBlank()) {
+            return "Unable to determine own pod name (HOSTNAME not set)";
+        }
+        return fetchLogs(selfId, tailLines);
+    }
+
+    @Override
+    public String fetchSessionTranscript(String name, String sessionId) {
+        ExecResult r = exec(
+            name,
+            List.of(
+                "sh",
+                "-c",
+                "cat \"$(find /root/.claude/projects -name '" + sessionId + ".jsonl' 2>/dev/null | head -1)\" 2>/dev/null"
+            ),
+            null,
+            Duration.ofSeconds(30),
+            null
+        );
+        return r.stdout();
+    }
+
+    // ── File transfer ────────────────────────────────────────
+
+    @Override
+    public byte[] copyFromContainer(String name, String path) {
+        Capture c = execCapture(name, List.of("cat", path), null, Duration.ofSeconds(30), null);
+        if (c.exitCode != 0) {
+            throw new RuntimeException("Failed to read " + name + ":" + path + ": " + c.stderr);
+        }
+        return c.stdout;
+    }
+
+    @Override
+    public void copyToContainer(String name, String destDir, byte[] data, String filename) {
+        String safePath = destDir + "/" + filename;
+        ExecResult result = exec(
+            name,
+            List.of("sh", "-c", "cat > '" + safePath.replace("'", "'\\''") + "'"),
+            null,
+            Duration.ofSeconds(30),
+            new String(data, StandardCharsets.UTF_8)
+        );
+        if (result.exitCode() != 0) {
+            throw new RuntimeException("Failed to copy to " + name + ":" + safePath + ": " + result.stderr());
+        }
+    }
+
+    // ── State ────────────────────────────────────────────────
+
+    @Override
+    public ContainerState readState(String name) {
+        try {
+            byte[] data = copyFromContainer(name, STATE_PATH);
+            return MAPPER.readValue(data, ContainerState.class);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read state from: " + name, e);
+        }
+    }
+
+    @Override
+    public void writeState(String name, ContainerState state) {
+        try {
+            byte[] data = MAPPER.writeValueAsBytes(state);
+            copyToContainer(name, "/tmp", data, "smithy-state.json");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to write state to: " + name, e);
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────
+
+    private PodResource pod(String name) {
+        return client.pods().inNamespace(namespace).withName(name);
+    }
+
+    private static String phase(Pod p) {
+        return p.getStatus() != null ? p.getStatus().getPhase() : null;
+    }
+
+    /** Returns a human-readable reason if the task container is stuck pulling its image, else null. */
+    private static String imagePullError(Pod p) {
+        if (p.getStatus() == null || p.getStatus().getContainerStatuses() == null) {
+            return null;
+        }
+        for (ContainerStatus cs : p.getStatus().getContainerStatuses()) {
+            if (cs.getState() != null && cs.getState().getWaiting() != null) {
+                String reason = cs.getState().getWaiting().getReason();
+                if ("ImagePullBackOff".equals(reason) || "ErrImagePull".equals(reason) || "InvalidImageName".equals(reason)) {
+                    return reason + ": " + cs.getState().getWaiting().getMessage();
+                }
+            }
+        }
+        return null;
+    }
+
+    private static EnvVar envVar(String name, String value) {
+        return new EnvVar(name, value == null ? "" : value, null);
+    }
+
+    private static Map<String, Quantity> resourceMap(String cpu, String memory) {
+        var map = new LinkedHashMap<String, Quantity>();
+        if (cpu != null && !cpu.isBlank()) {
+            map.put("cpu", new Quantity(cpu.strip()));
+        }
+        if (memory != null && !memory.isBlank()) {
+            map.put("memory", new Quantity(memory.strip()));
+        }
+        return map;
+    }
+
+    /** Kubernetes volume names must be DNS-1123 labels (lowercase alphanumeric and '-'). */
+    private static String sanitizeVolumeName(String raw) {
+        String v = raw.toLowerCase().replaceAll("[^a-z0-9-]", "-");
+        v = v.replaceAll("(^-+)|(-+$)", "");
+        return v.isBlank() ? "cache" : v;
+    }
+
+    private static void sleep() {
+        try {
+            Thread.sleep(INIT_POLL_INTERVAL_MS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while polling Pod state", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+}

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/DashboardController.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/DashboardController.java
@@ -1,6 +1,6 @@
 package dev.smithyai.orchestrator.web;
 
-import dev.smithyai.orchestrator.service.docker.ContainerService;
+import dev.smithyai.orchestrator.service.docker.ContainerRuntime;
 import dev.smithyai.orchestrator.web.dto.InstanceDto;
 import dev.smithyai.orchestrator.workflow.shared.AbstractWorkflowFactory;
 import java.util.ArrayList;
@@ -18,9 +18,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class DashboardController {
 
     private final List<AbstractWorkflowFactory<?>> factories;
-    private final ContainerService containerService;
+    private final ContainerRuntime containerService;
 
-    public DashboardController(List<AbstractWorkflowFactory<?>> factories, ContainerService containerService) {
+    public DashboardController(List<AbstractWorkflowFactory<?>> factories, ContainerRuntime containerService) {
         this.factories = factories;
         this.containerService = containerService;
     }

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/WorkflowService.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/WorkflowService.java
@@ -1,7 +1,7 @@
 package dev.smithyai.orchestrator.workflow;
 
 import dev.smithyai.orchestrator.model.events.WorkflowEvent;
-import dev.smithyai.orchestrator.service.docker.ContainerService;
+import dev.smithyai.orchestrator.service.docker.ContainerRuntime;
 import dev.smithyai.orchestrator.service.docker.dto.ContainerState;
 import dev.smithyai.orchestrator.workflow.shared.AbstractWorkflowFactory;
 import dev.smithyai.orchestrator.workflow.shared.AbstractWorkflowInstance;
@@ -16,9 +16,9 @@ import org.springframework.stereotype.Component;
 public class WorkflowService {
 
     private final List<AbstractWorkflowFactory<?>> factories;
-    private final ContainerService containerService;
+    private final ContainerRuntime containerService;
 
-    public WorkflowService(List<AbstractWorkflowFactory<?>> factories, ContainerService containerService) {
+    public WorkflowService(List<AbstractWorkflowFactory<?>> factories, ContainerRuntime containerService) {
         this.factories = factories;
         this.containerService = containerService;
         log.info("WorkflowService initialized with {} workflow factories", factories.size());

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/flows/architect/ArchitectLearnFactory.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/flows/architect/ArchitectLearnFactory.java
@@ -5,7 +5,7 @@ import dev.smithyai.orchestrator.config.DockerConfig;
 import dev.smithyai.orchestrator.config.VcsProviderConfig;
 import dev.smithyai.orchestrator.model.events.WorkflowEvent;
 import dev.smithyai.orchestrator.service.claude.PromptRenderer;
-import dev.smithyai.orchestrator.service.docker.ContainerService;
+import dev.smithyai.orchestrator.service.docker.ContainerRuntime;
 import dev.smithyai.orchestrator.service.docker.dto.ContainerState;
 import dev.smithyai.orchestrator.service.docker.dto.WorkflowType;
 import dev.smithyai.orchestrator.service.vcs.IssueTrackerClient;
@@ -24,7 +24,7 @@ public class ArchitectLearnFactory extends AbstractWorkflowFactory<ArchitectLear
 
     public static final List<String> TOOLS = List.of("Read", "Glob", "Grep", "Edit", "Write", "Bash");
 
-    private final ContainerService containerService;
+    private final ContainerRuntime containerService;
     private final DockerConfig dockerConfig;
     private final VcsProviderConfig vcsConfig;
     private final PromptRenderer renderer;
@@ -36,7 +36,7 @@ public class ArchitectLearnFactory extends AbstractWorkflowFactory<ArchitectLear
         DockerConfig dockerConfig,
         VcsProviderConfig vcsConfig,
         BotConfig botConfig,
-        ContainerService containerService,
+        ContainerRuntime containerService,
         PromptRenderer renderer,
         @Qualifier("architectVcs") VcsClient vcsClient,
         @Qualifier("architectIssueTracker") IssueTrackerClient issueTracker

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/flows/architect/ArchitectReviewFactory.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/flows/architect/ArchitectReviewFactory.java
@@ -5,7 +5,7 @@ import dev.smithyai.orchestrator.config.DockerConfig;
 import dev.smithyai.orchestrator.config.VcsProviderConfig;
 import dev.smithyai.orchestrator.model.events.WorkflowEvent;
 import dev.smithyai.orchestrator.service.claude.PromptRenderer;
-import dev.smithyai.orchestrator.service.docker.ContainerService;
+import dev.smithyai.orchestrator.service.docker.ContainerRuntime;
 import dev.smithyai.orchestrator.service.docker.dto.ContainerState;
 import dev.smithyai.orchestrator.service.docker.dto.WorkflowType;
 import dev.smithyai.orchestrator.service.vcs.IssueTrackerClient;
@@ -24,7 +24,7 @@ public class ArchitectReviewFactory extends AbstractWorkflowFactory<ArchitectRev
 
     public static final List<String> TOOLS = List.of("Read", "Glob", "Grep", "Bash");
 
-    private final ContainerService containerService;
+    private final ContainerRuntime containerService;
     private final DockerConfig dockerConfig;
     private final VcsProviderConfig vcsConfig;
     private final PromptRenderer renderer;
@@ -36,7 +36,7 @@ public class ArchitectReviewFactory extends AbstractWorkflowFactory<ArchitectRev
         DockerConfig dockerConfig,
         VcsProviderConfig vcsConfig,
         BotConfig botConfig,
-        ContainerService containerService,
+        ContainerRuntime containerService,
         PromptRenderer renderer,
         @Qualifier("architectVcs") VcsClient vcsClient,
         @Qualifier("architectIssueTracker") IssueTrackerClient issueTracker

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/flows/smithy/SmithyWorkflowFactory.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/flows/smithy/SmithyWorkflowFactory.java
@@ -6,7 +6,7 @@ import dev.smithyai.orchestrator.config.KnowledgebaseConfig;
 import dev.smithyai.orchestrator.config.VcsProviderConfig;
 import dev.smithyai.orchestrator.model.events.WorkflowEvent;
 import dev.smithyai.orchestrator.service.claude.PromptRenderer;
-import dev.smithyai.orchestrator.service.docker.ContainerService;
+import dev.smithyai.orchestrator.service.docker.ContainerRuntime;
 import dev.smithyai.orchestrator.service.docker.dto.ContainerState;
 import dev.smithyai.orchestrator.service.docker.dto.WorkflowType;
 import dev.smithyai.orchestrator.service.vcs.IssueTrackerClient;
@@ -26,7 +26,7 @@ public class SmithyWorkflowFactory extends AbstractWorkflowFactory<SmithyWorkflo
     public static final List<String> REFINE_TOOLS = List.of("Read", "Write", "Glob", "Grep", "Bash");
     public static final List<String> BUILD_TOOLS = List.of("Read", "Edit", "Write", "Bash");
 
-    private final ContainerService containerService;
+    private final ContainerRuntime containerService;
     private final DockerConfig dockerConfig;
     private final VcsProviderConfig vcsConfig;
     private final KnowledgebaseConfig knowledgebaseConfig;
@@ -40,7 +40,7 @@ public class SmithyWorkflowFactory extends AbstractWorkflowFactory<SmithyWorkflo
         VcsProviderConfig vcsConfig,
         KnowledgebaseConfig knowledgebaseConfig,
         BotConfig botConfig,
-        ContainerService containerService,
+        ContainerRuntime containerService,
         PromptRenderer renderer,
         @Qualifier("smithyVcs") VcsClient vcsClient,
         @Qualifier("smithyIssueTracker") IssueTrackerClient issueTracker

--- a/orchestrator/backend/src/main/resources/orchestrator.yml
+++ b/orchestrator/backend/src/main/resources/orchestrator.yml
@@ -1,3 +1,17 @@
+runtime:
+  # Task-container backend: 'docker' (shell out to the docker CLI) or 'kubernetes' (launch task Pods).
+  type: ${SMITHY_RUNTIME:docker}
+  kubernetes:
+    namespace: ${KUBERNETES_NAMESPACE:smithy}
+    task-service-account: ${TASK_SERVICE_ACCOUNT:}
+    image-pull-secret: ${TASK_IMAGE_PULL_SECRET:}
+    task-cpu-request: ${TASK_CPU_REQUEST:250m}
+    task-memory-request: ${TASK_MEMORY_REQUEST:512Mi}
+    task-cpu-limit: ${TASK_CPU_LIMIT:}
+    task-memory-limit: ${TASK_MEMORY_LIMIT:}
+    cache-persistence: ${TASK_CACHE_PERSISTENCE:false}
+    storage-class: ${TASK_STORAGE_CLASS:}
+
 docker:
   command: ${DOCKER_COMMAND:docker}
   network: ${DOCKER_NETWORK:forgejo-net}

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/service/docker/KubernetesContainerRuntimeTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/service/docker/KubernetesContainerRuntimeTest.java
@@ -1,0 +1,135 @@
+package dev.smithyai.orchestrator.service.docker;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.smithyai.orchestrator.config.BotConfig;
+import dev.smithyai.orchestrator.config.ClaudeConfig;
+import dev.smithyai.orchestrator.config.DockerConfig;
+import dev.smithyai.orchestrator.config.RuntimeConfig.KubernetesRuntimeConfig;
+import dev.smithyai.orchestrator.config.VcsProviderConfig;
+import dev.smithyai.orchestrator.config.VcsProviderConfig.ForgejoProviderConfig;
+import dev.smithyai.orchestrator.service.docker.dto.ContainerConfig;
+import dev.smithyai.orchestrator.service.docker.dto.WorkflowType;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link KubernetesContainerRuntime} against the Fabric8 CRUD mock server. Exec and
+ * log streaming require a live container and are not exercised here; Pod construction and
+ * label-based discovery/cleanup are.
+ */
+@EnableKubernetesMockClient(crud = true)
+class KubernetesContainerRuntimeTest {
+
+    // Injected by the Fabric8 mock extension.
+    static KubernetesClient client;
+
+    private static final String NS = "smithy";
+
+    private KubernetesContainerRuntime runtime() {
+        var k8s = new KubernetesRuntimeConfig(NS, null, null, "250m", "512Mi", null, null, false, null);
+        var docker = new DockerConfig("docker", "forgejo-net", "ghcr.io/smithy-ai/claude-task-default:dev", "pnpm,npm");
+        var claude = new ClaudeConfig("oauth-abc", null);
+        var vcs = new VcsProviderConfig(
+            "forgejo",
+            null,
+            new ForgejoProviderConfig("http://forgejo:3000", null, "wh", "smithy-token", null),
+            null,
+            null
+        );
+        var bots = new BotConfig(new BotConfig.BotEntry("smithy", "smithy@example.com"), null);
+        return new KubernetesContainerRuntime(client, k8s, docker, claude, vcs, bots);
+    }
+
+    private ContainerConfig taskConfig() {
+        Map<String, String> cache = new LinkedHashMap<>();
+        cache.put("cache-pnpm", "/root/.local/share/pnpm/store");
+        return ContainerConfig.builder()
+            .cloneUrl("http://forgejo:3000/owner/repo.git")
+            .branch("smithy/42-feature")
+            .cacheVolumes(cache)
+            .workflowType(WorkflowType.SMITHY)
+            .build();
+    }
+
+    @Test
+    void buildPodSetsImageLabelsEnvAndSpec() {
+        Pod pod = runtime().buildPod("smithy-42", taskConfig());
+
+        assertEquals("smithy-42", pod.getMetadata().getName());
+        assertEquals(NS, pod.getMetadata().getNamespace());
+        assertEquals("true", pod.getMetadata().getLabels().get("smithy.managed"));
+        assertEquals("smithy", pod.getMetadata().getLabels().get("smithy.workflow"));
+
+        var spec = pod.getSpec();
+        assertEquals("Never", spec.getRestartPolicy());
+        assertFalse(spec.getAutomountServiceAccountToken());
+
+        var container = spec.getContainers().get(0);
+        assertEquals("ghcr.io/smithy-ai/claude-task-default:dev", container.getImage());
+        assertEquals(List.of("smithy-init"), container.getCommand());
+
+        Map<String, String> env = new LinkedHashMap<>();
+        container.getEnv().forEach(e -> env.put(e.getName(), e.getValue()));
+        assertEquals("oauth-abc", env.get("CLAUDE_CODE_OAUTH_TOKEN"));
+        assertEquals("http://forgejo:3000", env.get("VCS_URL"));
+        assertEquals("smithy-token", env.get("VCS_TOKEN"));
+        assertEquals("http://forgejo:3000/owner/repo.git", env.get("CLONE_URL"));
+        assertEquals("smithy/42-feature", env.get("BRANCH"));
+
+        // Cache volume mounted with a DNS-1123-safe name.
+        assertEquals(1, container.getVolumeMounts().size());
+        assertEquals("/root/.local/share/pnpm/store", container.getVolumeMounts().get(0).getMountPath());
+        assertEquals("cache-pnpm", container.getVolumeMounts().get(0).getName());
+        assertNotNull(spec.getVolumes().get(0).getEmptyDir());
+    }
+
+    @Test
+    void discoversAndDestroysManagedPods() {
+        var runtime = runtime();
+
+        // A running managed Pod should be discoverable; an unmanaged one should not.
+        client.pods().inNamespace(NS).resource(managedRunningPod("task-a")).create();
+        client.pods().inNamespace(NS).resource(unmanagedPod("other")).create();
+
+        assertTrue(runtime.containerExists("task-a"));
+        assertTrue(runtime.isManagedContainer("task-a"));
+        assertFalse(runtime.isManagedContainer("other"));
+        assertEquals(List.of("task-a"), runtime.listManagedContainers());
+
+        runtime.destroy("task-a");
+        assertFalse(runtime.containerExists("task-a"));
+        assertTrue(runtime.listManagedContainers().isEmpty());
+    }
+
+    private static Pod managedRunningPod(String name) {
+        return new PodBuilder()
+            .withNewMetadata()
+            .withName(name)
+            .withNamespace(NS)
+            .addToLabels("smithy.managed", "true")
+            .endMetadata()
+            .withNewStatus()
+            .withPhase("Running")
+            .endStatus()
+            .build();
+    }
+
+    private static Pod unmanagedPod(String name) {
+        return new PodBuilder()
+            .withNewMetadata()
+            .withName(name)
+            .withNamespace(NS)
+            .endMetadata()
+            .withNewStatus()
+            .withPhase("Running")
+            .endStatus()
+            .build();
+    }
+}


### PR DESCRIPTION
## Why

Smithy currently only runs as a Docker Compose stack: the orchestrator mounts `/var/run/docker.sock` and shells out to the `docker` CLI to spawn **long-lived task containers it repeatedly execs into**. That ties every deployment to a single Docker host and blocks running on a real cluster. This PR makes the task backend pluggable and adds first-class Kubernetes support — deploy the orchestrator as a workload, and let it launch tasks as **Pods** instead of Docker containers.

Docker stays the default, so existing Compose users are unaffected — Kubernetes is opt-in via config.

## What changed

### Container runtime abstraction (`orchestrator/backend`)
- New `ContainerRuntime` interface; `ContainerSession` and all consumers (`WorkflowService`, `DashboardController`, the workflow factories) depend on it instead of the concrete service.
- `DockerContainerRuntime` — the existing `docker` CLI behavior, unchanged (renamed from `ContainerService`).
- `KubernetesContainerRuntime` — launches each task as a Pod via the Fabric8 client: create Pod (`restartPolicy: Never`, `smithy.managed`/`smithy.workflow` labels, `automountServiceAccountToken: false`), exec in `/workspace` with env/stdin/timeout, tail logs, copy files via exec, label-based discovery/cleanup, init-marker polling + `ImagePullBackOff` detection.
- Runtime selected by `runtime.type` / `SMITHY_RUNTIME` (`docker` | `kubernetes`), wired by `RuntimeConfiguration`; unknown values fail fast. Only the selected implementation is instantiated.
- Added `io.fabric8:kubernetes-client:7.3.1` + a mock-server unit test.

### Deployment packaging (`deploy/`)
- **Helm chart** `deploy/helm/smithy`: Deployment, Service, ServiceAccount, **namespaced** Role+RoleBinding (`pods`, `pods/log`, `pods/exec` only — no ClusterRole, no docker socket mounted), ConfigMap, Secret (with `existingSecret` override), optional Ingress, optional bundled Forgejo + knowledgebase with PVCs. Defaults `SMITHY_RUNTIME=kubernetes`.
- **Kustomize base** `deploy/k8s` for non-Helm installs.
- `deploy/README.md` + a "Running on Kubernetes" section in the root `README.md`.

### Design docs
- Captured as an OpenSpec change under `openspec/changes/add-kubernetes-deployment/` (proposal, specs, design, tasks).

## Testing
- `./gradlew :backend:test` — full suite green, including the refactor (no behavior change for the Docker runtime) and the new `KubernetesContainerRuntimeTest` (Pod build, label discovery, cleanup) against the Fabric8 mock server.
- `helm lint` + `helm template` render valid manifests for default and all-features (`--set knowledgebase.enabled=true --set forgejo.enabled=true --set ingress.enabled=true`); `kubectl kustomize deploy/k8s` builds. Confirmed no docker socket, `SMITHY_RUNTIME=kubernetes`, RBAC, and `/api/health` probes in the rendered Deployment.

## Not covered / follow-ups
- No live-cluster smoke test (kind/minikube) yet — the runtime is unit-tested against the Fabric8 mock server but not exercised end-to-end on a cluster.
- Task-Pod cache volumes use `emptyDir` (no cross-task cache reuse); PVC-backed caching is left as a follow-up.
- `spotlessApply` couldn't run in my local env (an npm-flag incompatibility unrelated to this change); new files follow the project's prettier config manually. Please confirm CI spotless is happy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)