### PR TITLE
Hotfix: user content evaluated as Jinja templates + PR events matched by branch

### DIFF
--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/ExpressionRenderer.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/ExpressionRenderer.java
@@ -22,7 +22,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class ExpressionRenderer {
 
-    private final Jinjava jinjava = new Jinjava(JinjavaConfig.newBuilder().build());
+    // Nested interpretation off: a substituted value is user content — a Jira
+    // story whose body carries `{{monospace}}` markup must not be evaluated as
+    // a template of ours.
+    private final Jinjava jinjava = new Jinjava(JinjavaConfig.newBuilder().withNestedInterpretationEnabled(false).build());
 
     {
         // Two text helpers the built-in flows need and that no amount of

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunEngine.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunEngine.java
@@ -252,13 +252,20 @@ public class RunEngine implements SignalDelivery {
         };
     }
 
-    /** The branch a push or CI event is about. */
+    /**
+     * The branch a push or CI event is about.
+     *
+     * <p>Deliberately not PR-scoped events: those name their pull request, and
+     * that is the only handle that may find a run for them. Matching them by
+     * branch made a run adopt someone else's merge request from the same
+     * branch — a human's MR opened from the agent's work branch got the agent
+     * answering its comments and pushing to it, with no assignment anywhere.
+     */
     private static Optional<String> branchOf(WorkflowEvent event) {
         return switch (event) {
             case WorkflowEvent.HumanPush push -> Optional.ofNullable(push.branch());
             case WorkflowEvent.CiFailure ci -> Optional.ofNullable(ci.ciRun().headBranch());
             case WorkflowEvent.CiRecovery ci -> Optional.ofNullable(ci.ciRun().headBranch());
-            case WorkflowEvent.PrScoped pr -> Optional.ofNullable(pr.prc().headBranch());
             default -> Optional.empty();
         };
     }

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/claude/PromptRenderer.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/claude/PromptRenderer.java
@@ -20,7 +20,10 @@ public class PromptRenderer {
 
     public PromptRenderer(ResourceLoader resourceLoader) {
         this.resourceLoader = resourceLoader;
-        this.jinjava = new Jinjava(JinjavaConfig.newBuilder().build());
+        // Nested interpretation off: issue titles and bodies land in template
+        // variables, and `{{...}}` inside them (Jira monospace markup, code
+        // snippets) must stay text rather than be evaluated.
+        this.jinjava = new Jinjava(JinjavaConfig.newBuilder().withNestedInterpretationEnabled(false).build());
     }
 
     public String render(String templateName, Map<String, Object> variables) {

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/DefinitionAndExpressionTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/DefinitionAndExpressionTest.java
@@ -144,6 +144,27 @@ class DefinitionAndExpressionTest {
     }
 
     @Test
+    void issueContentIsSubstitutedAsTextNotEvaluatedAsATemplate() {
+        // Jira renders {{text}} as monospace, so story bodies routinely carry
+        // it. A substituted value is user content: it must come through
+        // verbatim, not be parsed as an expression of ours.
+        var event = new WorkflowEvent.IssueAssigned(
+            new IssueContext(REPO, "7", "A feature", "Go to {{Add to Wait List > Step 2}} and press save", "main"),
+            "https://git.invalid/acme/app"
+        );
+        var context = contextFor(event, Map.of());
+
+        assertEquals(
+            "Go to {{Add to Wait List > Step 2}} and press save",
+            renderer.render("{{ event.issueBody }}", context)
+        );
+        assertEquals(
+            "Working on: Go to {{Add to Wait List > Step 2}} and press save",
+            renderer.render("Working on: {{ event.issueBody }}", context)
+        );
+    }
+
+    @Test
     void rendersNestedStructuresRecursively() {
         var inputs = Map.<String, Object>of(
             "context",

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/RunEngineTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/RunEngineTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.smithyai.orchestrator.config.WorkflowPolicyConfig;
 import dev.smithyai.orchestrator.model.IssueContext;
+import dev.smithyai.orchestrator.model.PrContext;
 import dev.smithyai.orchestrator.model.RepoInfo;
 import dev.smithyai.orchestrator.model.events.WorkflowEvent;
 import dev.smithyai.orchestrator.runtime.actions.*;
@@ -60,6 +61,9 @@ class RunEngineTest {
           - event: [pr.merged, issue.unassigned]
             action: destroy
             key: "{{ repo.fullName }}#{{ event.issueRef }}"
+          - event: pr.commented
+            action: dispatch
+            by: pr
         state:
           initial: planning
           terminal: done
@@ -80,6 +84,11 @@ class RunEngineTest {
                   - uses: metrics.record
                     with:
                       name: plan_approved
+              pr.commented:
+                steps:
+                  - uses: state.var
+                    with:
+                      lastPrComment: "{{ event.commentBody }}"
           executing:
             on:
               issue.commented:
@@ -343,6 +352,37 @@ class RunEngineTest {
 
         assertFalse(again.handled());
         assertEquals(RunStatus.COMPLETED, store.find(started.runId()).orElseThrow().status());
+    }
+
+    @Test
+    void aCommentOnSomeoneElsesPrFromTheSameBranchDoesNotReachTheRun() {
+        var started = engine.handle(assigned()).getFirst();
+        // What the run registers when it opens its own pull request.
+        store.correlate(CorrelationKind.PR, RunRecorder.prRef("acme", "platform", 41), started.runId());
+        store.correlate(CorrelationKind.BRANCH, RunRecorder.branchRef("acme", "platform", "ecd-9"), started.runId());
+
+        // A human opened MR 42 from the run's work branch. Its comments are
+        // theirs: the run must not answer them just because the branch matches.
+        var strangers = engine
+            .handle(prComment(42, "please ignore this MR"))
+            .getFirst();
+        assertFalse(strangers.handled());
+        assertNull(store.find(started.runId()).orElseThrow().vars().get("lastPrComment"));
+
+        // The run's own MR still reaches it, through the PR it registered.
+        var own = engine.handle(prComment(41, "looks good")).getFirst();
+        assertTrue(own.handled());
+        assertEquals("looks good", store.find(started.runId()).orElseThrow().vars().get("lastPrComment"));
+    }
+
+    private static WorkflowEvent prComment(int number, String body) {
+        return new WorkflowEvent.PrConversationComment(
+            new PrContext(REPO, number, "ecd-9: a change", "", false, "ecd-9", "main"),
+            "b.human",
+            body,
+            number * 100L,
+            "d" + number
+        );
     }
 
     @Test


### PR DESCRIPTION
Two production incidents from the same deployment, one hotfix branch.

## 1. Issue content evaluated as Jinja templates (`c28aeab`)

Jinjava's default *nested interpretation* re-parses substituted values. A Jira story whose description carried `{{Add to Wait List > Step 2}}` (Jira's monospace wiki markup) crashed the whole `issue.assigned` transition with `FatalTemplateErrorsException` the moment `{{ event.issueBody }}` was rendered.

Fix: `withNestedInterpretationEnabled(false)` on both Jinjava instances (`ExpressionRenderer`, `PromptRenderer`). Workflow expressions and prompt templates are single-pass; substituted values are user content and must come through verbatim. This also closes a template-injection vector: issue text could previously reach the expression evaluator.

## 2. PR events matched to runs by branch (`b1f887e`)

When a `by: pr` lookup missed, `RunEngine` fell back to the *branch* correlation. A human opened an MR from the agent's work branch; every comment on that MR dispatched to the agent's run — it answered review comments and pushed commits to the human's branch, and since the bot was assigned nowhere on that MR, `pr.unassigned` could never fire to stop it.

Fix: `branchOf()` no longer matches PR-scoped events. A PR event names its pull request; only the PR correlation the run registered (`correlate kind: pr` after `pr.create`) can route it. Branch matching stays for pushes and CI runs, which carry nothing but a branch.

Behavioral note: workflows that open an MR but never correlate it (no `correlate kind: pr` step) will no longer receive that MR's events — as `smithy-development` already documents, the correlate steps are what the `by:` rules read.

## Tests

- Regression: an issue body containing `{{...}}` renders verbatim (alone and embedded).
- Regression: a comment on a stranger's MR from the run's own branch is ignored; the run's own correlated MR still reaches it.
- Full backend suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)