### PR TITLE
Skip repository-workflow lookup for tracker-only scopes

### DIFF
--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/definition/RepositoryWorkflowLoader.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/definition/RepositoryWorkflowLoader.java
@@ -65,6 +65,10 @@ public class RepositoryWorkflowLoader {
 
     public List<LoadedWorkflowDefinition> forRepository(RepoInfo info) {
         if (info == null || !workflowConfig.repositoryWorkflowsEnabled()) return List.of();
+        // A tracker-only scope — a Jira project standing in for a repository —
+        // has no repository behind it to list. Asking a VCS about it is a
+        // guaranteed 404, once per event per cache window.
+        if (info.cloneUrl() == null) return List.of();
         String key = info.source() + ":" + info.owner() + "/" + info.repo();
         var now = Instant.now();
         var cached = cache.get(key);

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/RepositoryWorkflowTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/RepositoryWorkflowTest.java
@@ -136,6 +136,21 @@ class RepositoryWorkflowTest {
     }
 
     @Test
+    void aTrackerScopeWithNoRepositoryBehindItIsNeverLookedUp() {
+        // A Jira story without a repository field is scoped as PROJECT/PROJECT
+        // with no clone URL. There is nothing to list for it.
+        var neverCalled = new StubVcsClient() {
+            @Override
+            public List<String> listRepositoryFiles(String owner, String repo, String path, String ref) {
+                throw new AssertionError("a scope with no repository behind it must not be listed");
+            }
+        };
+        var loader = new RepositoryWorkflowLoader(neverCalled, new WorkflowDefinitionParser());
+
+        assertEquals(List.of(), loader.forRepository(new RepoInfo("YSIS", "YSIS", null, "jira")));
+    }
+
+    @Test
     void aRepositoryWithNoWorkflowsOfItsOwnIsUnaffected() {
         assertTrue(engine.handle(assigned()).isEmpty());
         assertTrue(store.findRecent(10).isEmpty());


### PR DESCRIPTION
Follow-up to #35. A Jira story without a repository field is scoped as `PROJECT/PROJECT` with no clone URL. `RepositoryWorkflowLoader` still asked the VCS to list `.smithy/workflows` for it — a guaranteed 404 (`Cannot list .smithy/workflows in YSIS/YSIS: GitLab API error 404 ...`) logged on every event, once per cache window.

Now a `RepoInfo` with no clone URL returns no repository workflows without any provider call — it has no repository to carry them. Regression test asserts the provider is never asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)