### PR TITLE
Tell the story what happened: child issues, plans, and merge requests

### DIFF
--- a/docs/src/workflows/reference.md
+++ b/docs/src/workflows/reference.md
@@ -57,7 +57,7 @@ state:                             # required unless `extends` is set
 
 | Name | Contents |
 |---|---|
-| `run` | `id`, `workflow`, `state` |
+| `run` | `id`, `workflow`, `state`, `parent` (the spawning run's id, empty for a standalone run — guard a `signal.emit` with `run.parent != ''`) |
 | `vars` | The workflow's `vars`, plus everything `state.var` has written. `vars.source` is set to the connector the run started from, unless the definition declares its own |
 | `steps` | `steps.<id>.<field>`: outputs of earlier steps in this transition |
 | `event` | See [events](#events) |
@@ -129,7 +129,10 @@ on it is how a feature for the coordinator is told from a task for the agent.
 Emitted by `signal.emit`, by the engine when a child run reaches a terminal state
 (`signal:child-done`, payload includes `child`, `workflow`, `status` and the
 child's vars), and by the dashboard when a gate is approved
-(`signal:gate-approved`, payload includes `key`).
+(`signal:gate-approved`, payload includes `key`). The built-in
+`smithy-development` also signals its parent, if it has one, when its merge
+request opens (`signal:pr-opened`, payload includes `owner`, `repo`, `issueRef`,
+`prNumber`, `url`) — the feature coordinator relays that link onto the story.
 
 ### Batching
 
@@ -211,6 +214,7 @@ on.
 | `issue.label` | `owner`, `repo`, `issue`, `label` or `labels[]` | none | `labels` |
 | `issue.comment` | `owner`, `repo`, `issue`, `body` | none | `commentId` |
 | `issue.read` | `owner`, `repo`, `issue` | none | `issueRef`, `title`, `body`, `state`, `assignees`, `labels`, `baseBranch` |
+| `issue.link` | `owner`, `repo`, `issue` | none | `url` |
 | `attachments.fetch` | `owner`, `repo`, `issue` | none | `paths`, `count` |
 
 ### Pull requests

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/actions/ReviewActions.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/actions/ReviewActions.java
@@ -462,6 +462,37 @@ public class ReviewActions {
         };
     }
 
+    /** A link to an issue that works outside the network the orchestrator is on. */
+    @Bean
+    public WorkflowAction issueLinkAction(VcsClients clients) {
+        return new WorkflowAction() {
+            @Override
+            public String type() {
+                return "issue.link";
+            }
+
+            @Override
+            public boolean idempotent() {
+                return true;
+            }
+
+            @Override
+            public Map<String, Object> execute(ActionContext context, Map<String, Object> input) {
+                var vcs = Vcs.pick(this, context, input, clients);
+                String target = Vcs.target(this, context, input, clients);
+                return Map.of(
+                    "url",
+                    vcs.issueUrl(
+                        clients.externalUrl(target),
+                        required(input, "owner"),
+                        required(input, "repo"),
+                        required(input, "issue")
+                    )
+                );
+            }
+        };
+    }
+
     /**
      * A browsable link to a file on a branch.
      *

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/ExpressionRenderer.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/ExpressionRenderer.java
@@ -159,7 +159,18 @@ public class ExpressionRenderer {
     private Map<String, Object> runView(ActionContext context) {
         var run = context.run();
         if (run == null) return Map.of();
-        return Map.of("id", run.id(), "workflow", run.workflowName(), "state", run.state());
+        // `parent` is empty rather than absent for a standalone run, so a
+        // definition can guard a signal.emit with `run.parent != ''`.
+        return Map.of(
+            "id",
+            run.id(),
+            "workflow",
+            run.workflowName(),
+            "state",
+            run.state(),
+            "parent",
+            nullToEmpty(run.parentRunId())
+        );
     }
 
     private Map<String, Object> eventView(WorkflowEvent event) {

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/vcs/VcsClient.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/vcs/VcsClient.java
@@ -103,6 +103,8 @@ public interface VcsClient extends ProviderClient {
 
     String prUrl(String externalBaseUrl, String owner, String repo, int number);
 
+    String issueUrl(String externalBaseUrl, String owner, String repo, String issueRef);
+
     String cloneUrl(String owner, String repo);
 
     String baseUrl();

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/vcs/forgejo/ForgejoClient.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/vcs/forgejo/ForgejoClient.java
@@ -436,6 +436,11 @@ public class ForgejoClient implements VcsClient, IssueTrackerClient {
     }
 
     @Override
+    public String issueUrl(String externalBaseUrl, String owner, String repo, String issueRef) {
+        return externalBaseUrl + "/" + owner + "/" + repo + "/issues/" + issueRef;
+    }
+
+    @Override
     public String cloneUrl(String owner, String repo) {
         return baseUrl + "/" + owner + "/" + repo + ".git";
     }

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/vcs/github/GitHubClient.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/vcs/github/GitHubClient.java
@@ -264,6 +264,11 @@ public class GitHubClient implements VcsClient, IssueTrackerClient {
     }
 
     @Override
+    public String issueUrl(String externalBaseUrl, String owner, String repo, String issueRef) {
+        return externalBaseUrl + "/" + owner + "/" + repo + "/issues/" + issueRef;
+    }
+
+    @Override
     public String cloneUrl(String owner, String repo) {
         return webUrl + "/" + owner + "/" + repo + ".git";
     }

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/vcs/gitlab/GitLabClient.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/vcs/gitlab/GitLabClient.java
@@ -462,6 +462,11 @@ public class GitLabClient implements VcsClient, IssueTrackerClient {
     }
 
     @Override
+    public String issueUrl(String externalBaseUrl, String owner, String repo, String issueRef) {
+        return externalBaseUrl + "/" + owner + "/" + repo + "/-/issues/" + issueRef;
+    }
+
+    @Override
     public String cloneUrl(String owner, String repo) {
         return baseUrl + "/" + owner + "/" + repo + ".git";
     }

--- a/orchestrator/backend/src/main/resources/workflows/feature-coordinator.yml
+++ b/orchestrator/backend/src/main/resources/workflows/feature-coordinator.yml
@@ -145,6 +145,16 @@ actions:
               ref: "{{ item.owner }}/{{ item.repo }}#{{ steps.child_issue.issueRef }}"
               run: "{{ steps.child.runId }}"
 
+          # A browsable link for the summary comment below. The story may live
+          # in another system, where "owner/repo#4" resolves to nothing.
+          - uses: issue.link
+            id: child_link
+            with:
+              target: "{{ item.source if item.source else vars.childSource }}"
+              owner: "{{ item.owner }}"
+              repo: "{{ item.repo }}"
+              issue: "{{ steps.child_issue.issueRef }}"
+
       # Only the children whose dependencies are already satisfied start —
       # the rest wait for the wave they belong to.
       - uses: run.wave
@@ -161,6 +171,27 @@ actions:
               repo: "{{ item.repo }}"
               issue: "{{ item.issueRef }}"
               actors: ["{{ vars.childActor }}"]
+
+      # Approval otherwise looks like silence from the story: the issues appear
+      # in other repositories, the plans on those issues, the merge requests on
+      # those plans — none of it visible from where the feature was asked for.
+      - uses: issue.comment
+        with:
+          target: "{{ vars.storySource }}"
+          owner: "{{ vars.storyOwner }}"
+          repo: "{{ vars.storyRepo }}"
+          issue: "{{ vars.storyRef }}"
+          body: |-
+            Plan approved. I created {{ steps.fanout.count }} child issue(s):
+            {% for r in steps.fanout.results %}
+            - {{ vars.plan[loop.index0].owner }}/{{ vars.plan[loop.index0].repo }}: [{{ r.child_issue.title }}]({{ r.child_link.url }})
+            {%- endfor %}
+
+            {% if steps.wave.released | length > 0 -%}
+            Started now: {% for c in steps.wave.released %}{{ c.owner }}/{{ c.repo }}#{{ c.issueRef }}{% if not loop.last %}, {% endif %}{% endfor %}. The others start automatically once the issues they depend on are delivered.
+            {%- endif %}
+
+            **What's needed from you:** on each child issue the agent posts a development plan for that repository. Review it there and approve it the way this plan was approved; the merge request opens after that, and I'll post its link here.
 
       - uses: metrics.record
         with:
@@ -273,6 +304,22 @@ state:
 
   executing:
     on:
+      # A child opened its merge request. Relayed onto the story because that
+      # is where progress is followed, and a reader there has no reason to be
+      # watching another repository's notifications.
+      "signal:pr-opened":
+        steps:
+          - uses: issue.comment
+            with:
+              target: "{{ vars.storySource }}"
+              owner: "{{ vars.storyOwner }}"
+              repo: "{{ vars.storyRepo }}"
+              issue: "{{ vars.storyRef }}"
+              body: >-
+                {{ event.owner }}/{{ event.repo }}#{{ event.issueRef }} has an open
+                merge request: {{ event.url }} — review and merge it to move this
+                feature forward.
+
       # A child announcing it finished, straight from its run rather than via a
       # comment on the story that this workflow would have to recognise.
       "signal:child-done":
@@ -299,7 +346,11 @@ state:
               owner: "{{ vars.storyOwner }}"
               repo: "{{ vars.storyRepo }}"
               issue: "{{ vars.storyRef }}"
-              body: "A child finished. Next wave assigned."
+              body: >-
+                {{ event.owner }}/{{ event.repo }}#{{ event.issueRef }} is delivered.
+                Next up, assigned to {{ vars.childActor }}:
+                {% for c in steps.wave.released %}{{ c.owner }}/{{ c.repo }}#{{ c.issueRef }}{% if not loop.last %}, {% endif %}{% endfor %}
+                — a development plan will be posted on each for review.
 
           - uses: issue.comment
             if: "{{ steps.wave.complete }}"

--- a/orchestrator/backend/src/main/resources/workflows/smithy-development.yml
+++ b/orchestrator/backend/src/main/resources/workflows/smithy-development.yml
@@ -263,6 +263,13 @@ state:
               name: pr_opened
               pr: "{{ steps.pr.number }}"
 
+          - uses: pr.link
+            id: prLink
+            with:
+              owner: "{{ vars.owner }}"
+              repo: "{{ vars.repo }}"
+              number: "{{ steps.pr.number }}"
+
           # Approving a plan should have visible feedback where the approval
           # happened, not only on a pull request nobody has been told about.
           - uses: issue.comment
@@ -270,7 +277,20 @@ state:
               owner: "{{ vars.owner }}"
               repo: "{{ vars.repo }}"
               issue: "{{ vars.issueRef }}"
-              body: "Plan approved. Implementation started, follow progress on the draft pull request."
+              body: "Plan approved. Implementation started, follow progress on the draft pull request: {{ steps.prLink.url }}"
+
+          # Tell the coordinator, if there is one, where the work can be
+          # followed — it relays the link onto the story, whose readers never
+          # see this repository's notifications.
+          - uses: signal.emit
+            if: "{{ run.parent != '' }}"
+            with:
+              signal: pr-opened
+              owner: "{{ vars.owner }}"
+              repo: "{{ vars.repo }}"
+              issueRef: "{{ vars.issueRef }}"
+              prNumber: "{{ steps.pr.number }}"
+              url: "{{ steps.prLink.url }}"
 
           - uses: attachments.fetch
             id: attachments

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/FeatureCoordinatorTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/FeatureCoordinatorTest.java
@@ -251,6 +251,7 @@ class FeatureCoordinatorTest {
                 review.fileUrlAction(vcsClients),
                 review.repoCloneUrlAction(vcsClients),
                 review.prLinkAction(vcsClients),
+                review.issueLinkAction(vcsClients),
                 ci.ciRetryGuardAction(store, new CiConfig(false)),
                 ci.ciResetAction(store),
                 issueActions.issueLabelAction(trackers),
@@ -585,6 +586,53 @@ class FeatureCoordinatorTest {
         );
         assertEquals(2, store.findChildren(story().id()).size());
         assertEquals("executing", story().state());
+    }
+
+    @Test
+    void approvalTellsTheStoryWhatWasCreatedAndWhatComesNext() {
+        engine.handle(storyAssigned());
+        engine.handle(storyApproved());
+
+        // The child issues live in other repositories; without this comment,
+        // approval looks like silence from where the feature was asked for.
+        String summary = vcs.issueComments.getLast();
+        for (var created : vcs.createdIssues) {
+            assertTrue(
+                summary.contains("%s/%s/issues/%s".formatted(created.owner(), created.repo(), created.issueRef())),
+                "no link to " + created.owner() + "/" + created.repo() + " in: " + summary
+            );
+        }
+        assertTrue(summary.contains("What's needed from you"), summary);
+    }
+
+    @Test
+    void aChildsMergeRequestLinkIsRelayedOntoTheStory() {
+        engine.handle(storyAssigned());
+        engine.handle(storyApproved());
+
+        var child = store.findChildren(story().id()).getFirst();
+        var signal = new SignalEmitAction(store, this::deliverSignal);
+        signal.execute(
+            new ActionContext(store.find(child.id()).orElseThrow(), storyApproved(), Map.of(), child.vars()),
+            Map.of(
+                "signal",
+                "pr-opened",
+                "owner",
+                "acme",
+                "repo",
+                "api",
+                "issueRef",
+                "1",
+                "prNumber",
+                100,
+                "url",
+                "https://git.invalid/acme/api/pulls/100"
+            )
+        );
+
+        String relayed = vcs.issueComments.getLast();
+        assertTrue(relayed.contains("https://git.invalid/acme/api/pulls/100"), relayed);
+        assertTrue(relayed.contains("acme/api#1"), relayed);
     }
 
     @Test

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/ArchitectDefinitionTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/ArchitectDefinitionTest.java
@@ -154,6 +154,7 @@ class ArchitectDefinitionTest {
                 review.fileUrlAction(vcs.asRegistry()),
                 review.repoCloneUrlAction(vcs.asRegistry()),
                 review.prLinkAction(vcs.asRegistry()),
+                review.issueLinkAction(vcs.asRegistry()),
                 new CiActions().ciRetryGuardAction(store, new CiConfig(false)),
                 new CiActions().ciResetAction(store)
             )

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/LiveEndToEndIT.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/LiveEndToEndIT.java
@@ -333,6 +333,7 @@ class LiveEndToEndIT {
                 review.fileUrlAction(new dev.smithyai.orchestrator.service.vcs.VcsClients(vcs)),
                 review.repoCloneUrlAction(new dev.smithyai.orchestrator.service.vcs.VcsClients(vcs)),
                 review.prLinkAction(new dev.smithyai.orchestrator.service.vcs.VcsClients(vcs)),
+                review.issueLinkAction(new dev.smithyai.orchestrator.service.vcs.VcsClients(vcs)),
                 ci.ciRetryGuardAction(store, new CiConfig(false)),
                 ci.ciResetAction(store)
             )

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/SmithyDefinitionTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/SmithyDefinitionTest.java
@@ -158,6 +158,7 @@ class SmithyDefinitionTest {
                 review.fileUrlAction(vcs.asRegistry()),
                 review.repoCloneUrlAction(vcs.asRegistry()),
                 review.prLinkAction(vcs.asRegistry()),
+                review.issueLinkAction(vcs.asRegistry()),
                 ci.ciRetryGuardAction(store, new CiConfig(false)),
                 ci.ciResetAction(store)
             )

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/StubVcsClient.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/StubVcsClient.java
@@ -243,6 +243,11 @@ public class StubVcsClient implements VcsClient, IssueTrackerClient {
     }
 
     @Override
+    public String issueUrl(String externalBaseUrl, String owner, String repo, String issueRef) {
+        return "%s/%s/%s/issues/%s".formatted(externalBaseUrl, owner, repo, issueRef);
+    }
+
+    @Override
     public String cloneUrl(String owner, String repo) {
         return "https://git.invalid/%s/%s.git".formatted(owner, repo);
     }


### PR DESCRIPTION
## Why

A coordinator's approval looks like silence from the story: the child issues appear in other repositories, the plans on those issues, the merge requests on those plans — none of it visible from where the feature was asked for, and nothing tells the reader what is still needed from them (seen live on a Jira story where the PO was left asking "what is the status?").

## What the story hears now

**On fan-out** (feature-coordinator):
- A summary comment listing every child issue with a browsable link, which ones were assigned now vs. waiting on dependencies, and a "What's needed from you" paragraph: review and approve the development plan each child posts.

**When a child opens its merge request** (smithy-development → coordinator):
- The child emits a `pr-opened` signal to its parent (guarded with `run.parent != ''`, so standalone runs are unaffected), and the coordinator relays the MR link onto the story.
- The child's own "Plan approved. Implementation started…" comment now carries the draft MR link as well.

**When a child finishes:**
- The comment names the delivered issue and the issues the next wave assigned, instead of "A child finished. Next wave assigned."

## Supporting changes

- New `issue.link` action, backed by `VcsClient.issueUrl()` on GitLab/GitHub/Forgejo — a bare `owner/repo#4` resolves to nothing from a Jira story, so the story gets full URLs.
- `run.parent` exposed in the expression context (empty for a standalone run).
- Docs: action tables and the signal list in `docs/src/workflows/reference.md`.

## Tests

Two new tests in `FeatureCoordinatorTest` pin the behavior end-to-end through the real YAML: `approvalTellsTheStoryWhatWasCreatedAndWhatComesNext` and `aChildsMergeRequestLinkIsRelayedOntoTheStory`. Full `:backend:test` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)