### PR TITLE
Clone the context repo beside the work, so the agent builds with the design system

### DIFF
--- a/docs/src/workflows/reference.md
+++ b/docs/src/workflows/reference.md
@@ -247,10 +247,17 @@ provider username from the list. A failure to request the review is reported in
 | `file.url` | `owner`, `repo`, `branch`, `path` | none | `url` |
 | `file.delete` | `owner`, `repo`, `branch`, `path` | `message` | `deleted` |
 | `repo.cloneUrl` | `owner`, `repo` | none | `cloneUrl`, `fullName` |
-| `repo.context` | `owner`, `repo` | none | `owner`, `repo`, `fullName`, `cloneUrl` |
+| `repo.context` | `owner`, `repo` | none | `owner`, `repo`, `fullName`, `cloneUrl`, `exists` |
 
 `repo.context` reads where a repository keeps its guidelines from its own
-`.smithy/config.yml`.
+`.smithy/config.yml` (`context.repository`, default `<repo>-context`).
+`exists` says whether that repository is actually there, so a workflow that
+consults guidelines opportunistically can pass an empty clone URL to
+`container.init` — which skips the entry — instead of failing the clone. The
+built-in `smithy-development` does exactly that: when the context repository
+exists it is cloned at `/context-repo`, and the planning and building prompts
+tell the agent to follow it — for UI work, to build with the design-system
+components documented there.
 
 ### Run state
 

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/actions/AbstractAgentAction.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/actions/AbstractAgentAction.java
@@ -65,8 +65,10 @@ public abstract class AbstractAgentAction implements WorkflowAction {
     }
 
     private ClaudeSession configured(ClaudeSession agent, Map<String, Object> input) {
+        // Blank counts as absent: a template that renders "" for a repository
+        // with no context repo must not switch the knowledgebase on for it.
         String contextRepo = optional(input, "contextRepo", null);
-        if (contextRepo != null) agent.setContextRepoName(contextRepo);
+        if (contextRepo != null && !contextRepo.isBlank()) agent.setContextRepoName(contextRepo);
         agent.setModel(optional(input, "model", null));
         return agent;
     }

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/actions/RepoContextAction.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/actions/RepoContextAction.java
@@ -40,6 +40,10 @@ public class RepoContextAction implements WorkflowAction {
     @Override
     public Map<String, Object> execute(ActionContext context, Map<String, Object> input) {
         var contextRepo = repositoryConfig.contextRepository(required(input, "owner"), required(input, "repo"));
+        // Whether it actually exists, so a workflow that consults guidelines
+        // opportunistically can skip the clone instead of failing on the many
+        // repositories that have no context repo at all.
+        boolean exists = exists(contextRepo.owner(), contextRepo.repo());
         return Map.of(
             "owner",
             contextRepo.owner(),
@@ -48,7 +52,20 @@ public class RepoContextAction implements WorkflowAction {
             "fullName",
             contextRepo.fullName(),
             "cloneUrl",
-            vcs.cloneUrl(contextRepo.owner(), contextRepo.repo())
+            vcs.cloneUrl(contextRepo.owner(), contextRepo.repo()),
+            "exists",
+            exists
         );
+    }
+
+    private boolean exists(String owner, String repo) {
+        try {
+            return vcs.repoExists(owner, repo);
+        } catch (RuntimeException e) {
+            // Guidelines are an aid, not a dependency: a provider hiccup here
+            // must not stop the work itself.
+            log.warn("Could not check whether context repo {}/{} exists; treating it as absent", owner, repo, e);
+            return false;
+        }
     }
 }

--- a/orchestrator/backend/src/main/resources/prompts/building.md.j2
+++ b/orchestrator/backend/src/main/resources/prompts/building.md.j2
@@ -4,6 +4,11 @@ You are implementing issue {{ issue_ref }}: {{ issue_title }}
 
 Read the development plan at `{{ plan_file_path }}` and implement it.
 
+{% if context_repo %}
+## Project guidelines
+
+This repository's guidelines are cloned at `/context-repo` (from `{{ context_repo }}`). Follow them. For UI work, build with the components and patterns documented there — matching look and feel means reusing the design system, not approximating it with custom markup or styles.
+{% endif %}
 {% if attachments %}
 
 ## Attachments

--- a/orchestrator/backend/src/main/resources/prompts/refinement.md.j2
+++ b/orchestrator/backend/src/main/resources/prompts/refinement.md.j2
@@ -15,6 +15,12 @@ The following files were attached to this issue and are available in the contain
 
 You may read these files directly or copy them into the repository if needed.
 {% endif %}
+{% if context_repo %}
+
+## Project guidelines
+
+This repository's guidelines are cloned at `/context-repo` (from `{{ context_repo }}`). Read the parts relevant to this issue before planning. For UI work, plan around the components and patterns documented there — reuse them rather than inventing new ones, and say in the plan which ones you will use. If the issue asks for something the design system has no component for, note that in the plan instead of improvising one silently.
+{% endif %}
 
 ## Instructions
 

--- a/orchestrator/backend/src/main/resources/workflows/smithy-development.yml
+++ b/orchestrator/backend/src/main/resources/workflows/smithy-development.yml
@@ -65,6 +65,17 @@ state:
       issue.assigned:
         to: refine
         steps:
+          # Where this repository keeps its guidelines — a design system, an
+          # architecture handbook. Read from the repository's own
+          # .smithy/config.yml, defaulting to "<repo>-context". Cloned beside
+          # the work when it exists; most repositories have none, and an
+          # empty clone URL below makes container.init skip it silently.
+          - uses: repo.context
+            id: context
+            with:
+              owner: "{{ repo.owner }}"
+              repo: "{{ repo.name }}"
+
           - uses: container.init
             id: workspace
             with:
@@ -73,6 +84,9 @@ state:
               branch: "{{ vars.branchPrefix }}{{ event.issueRef }}-{{ event.issueTitle | slug }}"
               sourceBranch: "{{ event.baseBranch }}"
               stage: refine
+              extraRepos:
+                - cloneUrl: "{{ steps.context.cloneUrl if steps.context.exists else '' }}"
+                  path: /context-repo
 
           # smithy-init records the branch it forked from, resolving the
           # remote's default when the event did not name one — which for an
@@ -90,6 +104,8 @@ state:
               owner: "{{ repo.owner }}"
               repo: "{{ repo.name }}"
               baseBranch: "{{ steps.base.stdout }}"
+              # Blank when there is none, so later turns can test for it.
+              contextRepo: "{{ steps.context.repo if steps.context.exists else '' }}"
 
           # Designs carry requirements the issue text omits, and the agent
           # cannot follow a link out of its container.
@@ -107,12 +123,14 @@ state:
               mode: plan
               tools: "{{ vars.refineTools }}"
               template: refinement.md.j2
+              contextRepo: "{{ steps.context.repo if steps.context.exists else '' }}"
               vars:
                 issue_ref: "{{ event.issueRef }}"
                 issue_title: "{{ event.issueTitle }}"
                 issue_body: "{{ event.issueBody }}"
                 plan_file_path: "{{ vars.planDir }}/{{ event.issueRef }}.md"
                 attachments: "{{ steps.attachments.paths }}"
+                context_repo: "{{ steps.context.repo if steps.context.exists else '' }}"
 
           # An empty plan is a dead end, not a crash: say so and wait for more
           # context rather than leaving the issue silent.
@@ -203,6 +221,7 @@ state:
             with:
               tools: "{{ vars.refineTools }}"
               template: refinement_comment.md.j2
+              contextRepo: "{{ vars.contextRepo }}"
               vars:
                 issue_ref: "{{ vars.issueRef }}"
                 comment_body: "{{ event.commentBody }}"
@@ -307,11 +326,13 @@ state:
             with:
               tools: "{{ vars.buildTools }}"
               template: building.md.j2
+              contextRepo: "{{ vars.contextRepo }}"
               vars:
                 issue_ref: "{{ vars.issueRef }}"
                 issue_title: "{{ event.issueTitle }}"
                 plan_file_path: "{{ vars.planPath }}"
                 attachments: "{{ steps.attachments.paths }}"
+                context_repo: "{{ vars.contextRepo }}"
 
           - uses: agent.ensureCommitted
             with:

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/SmithyDefinitionTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/SmithyDefinitionTest.java
@@ -92,7 +92,10 @@ class SmithyDefinitionTest {
     // ── The definition ───────────────────────────────────────
 
     private Observed runDefinition(FakeDockerCli docker, boolean approve) {
-        var vcs = new StubVcsClient();
+        return runDefinition(docker, approve, new StubVcsClient());
+    }
+
+    private Observed runDefinition(FakeDockerCli docker, boolean approve, StubVcsClient vcs) {
         var store = freshStore("yaml-" + System.identityHashCode(docker));
         scriptAPlan(docker);
 
@@ -214,6 +217,40 @@ class SmithyDefinitionTest {
     @Test
     void assignmentCreatesTheWorkspaceContainer() {
         assertEquals(List.of(CONTAINER), runDefinition(new FakeDockerCli(), false).containers());
+    }
+
+    @Test
+    void theContextRepoIsClonedBesideTheWorkWhenItExists() {
+        var docker = new FakeDockerCli();
+        runDefinition(docker, false);
+
+        // acme/app-context exists in the stub, so the workspace clones it at
+        // /context-repo for the agent to read guidelines from.
+        String extraRepos = extraReposFromCreate(docker);
+        assertTrue(extraRepos.contains("acme/app-context"), extraRepos);
+        assertTrue(extraRepos.contains("/context-repo"), extraRepos);
+    }
+
+    @Test
+    void aRepositoryWithoutAContextRepoWorksWithoutOne() {
+        var docker = new FakeDockerCli();
+        var vcs = new StubVcsClient();
+        vcs.existingRepos.remove("acme/app-context");
+
+        var observed = runDefinition(docker, false, vcs);
+
+        assertEquals("refine", observed.runState(), "the missing repo did not stop the work");
+        assertEquals("", extraReposFromCreate(docker), "and nothing was cloned beside it");
+    }
+
+    private static String extraReposFromCreate(FakeDockerCli docker) {
+        for (var args : docker.invocations) {
+            if (args.isEmpty() || !"create".equals(args.getFirst())) continue;
+            for (String arg : args) {
+                if (arg.startsWith("EXTRA_REPOS=")) return arg.substring("EXTRA_REPOS=".length());
+            }
+        }
+        return null;
     }
 
     @Test


### PR DESCRIPTION
> Stacked on #38 (shares edits to `smithy-development.yml`); GitHub will retarget this to `main` when #38 merges.

## Why

A story with no designs attached gives the agent nothing about the project's look and feel: `smithy-development` clones only the work repository. The context repo — where a team keeps its design system and guidelines — was read solely by the architect, *after* the merge request already existed. Frontend work should consult it while planning and building, not be corrected against it afterwards.

## What changed

- `smithy-development` resolves the repository's context repo (`repo.context`, from the repo's own `.smithy/config.yml`, default `<repo>-context`) and clones it at `/context-repo` when it exists.
- `refinement.md.j2` and `building.md.j2` gain a "Project guidelines" section: plan around the components documented there, build with them ("matching look and feel means reusing the design system, not approximating it"), and flag in the plan when the design system lacks a needed component instead of improvising one.
- The knowledgebase MCP is enabled for the plan, plan-revision, and build turns (`contextRepo:` on `agent.run`).

## Making it safe for every repo

Most repositories have no context repo, so:

- `repo.context` now reports `exists` (provider errors degrade to `false` — guidelines are an aid, not a dependency).
- An absent context repo renders an empty clone URL, which `container.init` already skips silently.
- A blank `contextRepo` on `agent.run` is treated as absent rather than enabling the knowledgebase for a repository named `""`.

## Tests

`SmithyDefinitionTest`: `theContextRepoIsClonedBesideTheWorkWhenItExists` (the docker create carries `EXTRA_REPOS` with the context clone at `/context-repo`) and `aRepositoryWithoutAContextRepoWorksWithoutOne` (run still reaches `refine`, nothing cloned). Full `:backend:test` green.

## Rollout note

To point a repository at a shared design-system repo, add `.smithy/config.yml` to it:

```yaml
context:
  repository: gerimedica/design-system-context
```

The smithy bot account needs read access to that repository for the clone to succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)