### PR TITLE
dashboard: collapsible session turns, per-tab routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,4 @@
-# Python
-__pycache__/
-*.py[cod]
-*$py.class
-*.egg-info/
-*.egg
-dist/
-.venv/
-venv/
+# Python __pycache__/ *.py[cod] *$py.class *.egg-info/ *.egg dist/ .venv/ venv/
 
 # Java / Gradle
 .gradle/
@@ -45,3 +37,7 @@ Thumbs.db
 *.db
 *.db-wal
 *.db-shm
+
+# Dashboard dev fixtures: real Claude Code transcripts, dropped in locally to
+# develop the Session tab. The README beside them is committed; they are not.
+orchestrator/frontend/dev/fixtures/*.jsonl

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/SpaForwardingConfig.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/SpaForwardingConfig.java
@@ -4,11 +4,29 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/**
+ * The dashboard routes on the client, so a deep link or a reload on any of its
+ * paths has to serve the app shell rather than 404. Every route the frontend
+ * declares needs a match here; anything not listed falls through to the API
+ * and static handlers.
+ */
 @Configuration
 public class SpaForwardingConfig implements WebMvcConfigurer {
 
+    private static final String[] SPA_PATHS = {
+        "/login",
+        "/instances",
+        "/runs",
+        "/session",
+        "/session/**",
+        "/logs",
+        "/logs/**",
+    };
+
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
-        registry.addViewController("/login").setViewName("forward:/index.html");
+        for (String path : SPA_PATHS) {
+            registry.addViewController(path).setViewName("forward:/index.html");
+        }
     }
 }

--- a/orchestrator/frontend/dev/fixtures/README.md
+++ b/orchestrator/frontend/dev/fixtures/README.md
@@ -1,0 +1,23 @@
+# Session fixtures
+
+Transcripts used to develop the dashboard's Session tab without a running
+orchestrator. `*.jsonl` here is gitignored — these are real agent sessions and
+are nobody's business but yours.
+
+Drop one in as `session.jsonl` and `npm run dev` picks it up:
+
+```bash
+cp ~/.claude/projects/<project>/<session-id>.jsonl dev/fixtures/session.jsonl
+npm run dev
+```
+
+The dashboard then shows a single fake instance, `fixture.session.local`,
+whose session is that file. To use a transcript somewhere else instead:
+
+```bash
+SMITHY_SESSION_FIXTURE=/path/to/other.jsonl npm run dev
+```
+
+The format is Claude Code's own session log: one JSON object per line, with
+`type`, `uuid`, `timestamp` and `message`. Anything the app can't parse is
+skipped, so a partial or hand-written file is fine for testing edge cases.

--- a/orchestrator/frontend/dev/sessionFixture.ts
+++ b/orchestrator/frontend/dev/sessionFixture.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Plugin } from "vite";
+
+/**
+ * Serves the dashboard from a Claude Code transcript on disk instead of a live
+ * orchestrator, so the Session tab can be worked on without a running
+ * container. Drop a .jsonl in dev/fixtures/ (see the README there) or point
+ * SMITHY_SESSION_FIXTURE at one; with neither, the plugin does not load and
+ * every request proxies as usual.
+ */
+const DEFAULT_FIXTURE = "dev/fixtures/session.jsonl";
+const CONTAINER = "fixture.session.local";
+
+function resolveFixture(): string | null {
+  const configured = process.env.SMITHY_SESSION_FIXTURE;
+  if (configured) {
+    return configured.startsWith("~")
+      ? path.join(os.homedir(), configured.slice(1))
+      : path.resolve(configured);
+  }
+  const fallback = path.resolve(DEFAULT_FIXTURE);
+  return fs.existsSync(fallback) ? fallback : null;
+}
+
+type Reply = (res: ServerResponse) => void;
+
+function json(body: unknown): Reply {
+  return (res) => {
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(body));
+  };
+}
+
+function plain(body: string): Reply {
+  return (res) => {
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.end(body);
+  };
+}
+
+const fakeInstance = () => ({
+  containerName: CONTAINER,
+  workflowType: "smithy-development",
+  stage: "implementing",
+  lastProcessedAt: new Date().toISOString(),
+  ciPaused: false,
+  ciRetryCount: 0,
+  running: true,
+  humanControlled: false,
+});
+
+/** The endpoints the dashboard needs to render; anything else falls through. */
+function reply(url: string, method: string, file: string): Reply | null {
+  if (url === "/api/dashboard/instances") return json([fakeInstance()]);
+  if (url === "/api/dashboard/metrics") return json({ counts: {} });
+  if (url === "/api/dashboard/runs") return json([]);
+  if (url === "/api/logout") return (res) => res.end();
+
+  if (url.startsWith("/api/dashboard/session/")) {
+    return plain(fs.readFileSync(file, "utf-8"));
+  }
+  if (url.startsWith("/api/dashboard/logs/")) {
+    return plain("(no logs in fixture mode)\n");
+  }
+  if (url.startsWith("/api/dashboard/takeover/")) {
+    if (method === "DELETE") return (res) => res.end();
+    if (url.endsWith("/message")) return plain("ok");
+    return json({ active: true, expiresAt: null });
+  }
+  return null;
+}
+
+export function sessionFixture(): Plugin | false {
+  const file = resolveFixture();
+  if (!file) return false;
+
+  return {
+    name: "smithy-session-fixture",
+    apply: "serve",
+    configureServer(server) {
+      if (!fs.existsSync(file)) {
+        server.config.logger.error(`SMITHY_SESSION_FIXTURE: no such file: ${file}`);
+        return;
+      }
+      server.config.logger.info(`session fixture: ${file} as ${CONTAINER}`);
+
+      server.middlewares.use(
+        (req: IncomingMessage, res: ServerResponse, next: () => void) => {
+          const url = (req.url ?? "").split("?")[0];
+          const handler = reply(url, req.method ?? "GET", file);
+          if (handler) handler(res);
+          else next();
+        },
+      );
+    },
+  };
+}

--- a/orchestrator/frontend/src/App.tsx
+++ b/orchestrator/frontend/src/App.tsx
@@ -2,12 +2,22 @@ import { Routes, Route, Navigate } from "react-router-dom";
 import { LoginPage } from "./pages/LoginPage";
 import { DashboardPage } from "./pages/DashboardPage";
 
+/**
+ * Each dashboard tab is a real route, so the browser's back button moves
+ * between tabs instead of leaving the app. The selected instance is part of
+ * the path too, which makes a session link shareable.
+ */
 export function App() {
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
-      <Route path="/" element={<DashboardPage />} />
-      <Route path="*" element={<Navigate to="/" replace />} />
+      <Route path="/instances" element={<DashboardPage />} />
+      <Route path="/runs" element={<DashboardPage />} />
+      <Route path="/session" element={<DashboardPage />} />
+      <Route path="/session/:resource" element={<DashboardPage />} />
+      <Route path="/logs" element={<DashboardPage />} />
+      <Route path="/logs/:resource" element={<DashboardPage />} />
+      <Route path="*" element={<Navigate to="/instances" replace />} />
     </Routes>
   );
 }

--- a/orchestrator/frontend/src/components/MessageBubble.tsx
+++ b/orchestrator/frontend/src/components/MessageBubble.tsx
@@ -4,56 +4,53 @@ import remarkGfm from "remark-gfm";
 import type {
   SessionMessage,
   AssistantMessage,
-  UserMessage,
   ToolResultContent,
 } from "../lib/sessionTypes";
+import { userText } from "../lib/groupTurns";
+import { formatWhen } from "../lib/time";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { ToolCall } from "./ToolCall";
 
 interface MessageBubbleProps {
   message: SessionMessage;
   toolResults: Map<string, ToolResultContent>;
+  /**
+   * False for a step that continues the same speaker's run, so a turn of forty
+   * tool calls reads as one block instead of forty repeated name/time lines.
+   */
+  showHeader?: boolean;
 }
 
-function getUserText(msg: UserMessage): string {
-  if (typeof msg.message.content === "string") {
-    return msg.message.content;
-  }
-  return msg.message.content
-    .filter((b): b is { type: "text"; text: string } => b.type === "text")
-    .map((b) => b.text)
-    .join("\n");
-}
-
-function formatTime(ts: string): string {
-  const d = new Date(ts);
-  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-}
-
-export function MessageBubble({ message, toolResults }: MessageBubbleProps) {
+export function MessageBubble({
+  message,
+  toolResults,
+  showHeader = true,
+}: MessageBubbleProps) {
   if (message.type === "system") return null;
 
   if (message.type === "user") {
-    const text = getUserText(message);
+    const text = userText(message);
     if (!text.trim()) return null;
 
     return (
-      <Box py={6} px={16}>
-        <Box
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "baseline",
-            marginBottom: 1,
-          }}
-        >
-          <Text size="xs" fw={700} style={{ color: "#6ea1f7" }}>
-            You
-          </Text>
-          <Text size="xs" style={{ color: "#4a5568" }}>
-            {formatTime(message.timestamp)}
-          </Text>
-        </Box>
+      <Box py={showHeader ? 6 : 1} px={16}>
+        {showHeader && (
+          <Box
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "baseline",
+              marginBottom: 1,
+            }}
+          >
+            <Text size="xs" fw={700} style={{ color: "#6ea1f7" }}>
+              You
+            </Text>
+            <Text size="xs" style={{ color: "#4a5568" }}>
+              {formatWhen(message.timestamp)}
+            </Text>
+          </Box>
+        )}
         <Text
           size="sm"
           style={{ whiteSpace: "pre-wrap", lineHeight: 1.45, color: "#d4dae3" }}
@@ -67,22 +64,24 @@ export function MessageBubble({ message, toolResults }: MessageBubbleProps) {
   const assistant = message as AssistantMessage;
   const content = assistant.message.content;
   return (
-    <Box py={6} px={16}>
-      <Box
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "baseline",
-          marginBottom: 1,
-        }}
-      >
-        <Text size="xs" fw={700} style={{ color: "#e8965a" }}>
-          Claude
-        </Text>
-        <Text size="xs" style={{ color: "#4a5568" }}>
-          {formatTime(message.timestamp)}
-        </Text>
-      </Box>
+    <Box py={showHeader ? 6 : 1} px={16}>
+      {showHeader && (
+        <Box
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "baseline",
+            marginBottom: 1,
+          }}
+        >
+          <Text size="xs" fw={700} style={{ color: "#e8965a" }}>
+            Claude
+          </Text>
+          <Text size="xs" style={{ color: "#4a5568" }}>
+            {formatWhen(message.timestamp)}
+          </Text>
+        </Box>
+      )}
       {content.map((block, i) => {
         if (block.type === "thinking") {
           return <ThinkingBlock key={i} content={block.thinking} />;

--- a/orchestrator/frontend/src/components/TurnItem.tsx
+++ b/orchestrator/frontend/src/components/TurnItem.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { UnstyledButton, Collapse, Box, Text } from "@mantine/core";
+import type { Turn } from "../lib/groupTurns";
+import type { ToolResultContent } from "../lib/sessionTypes";
+import { MessageBubble } from "./MessageBubble";
+import { formatWhen } from "../lib/time";
+
+interface TurnItemProps {
+  turn: Turn;
+  toolResults: Map<string, ToolResultContent>;
+  opened: boolean;
+  isLatest: boolean;
+  onToggle: () => void;
+}
+
+function plural(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+function summarize(turn: Turn): string {
+  const parts: string[] = [];
+  if (turn.stepCount > 0) parts.push(plural(turn.stepCount, "step"));
+  if (turn.toolCount > 0) parts.push(plural(turn.toolCount, "tool"));
+  return parts.join(" · ");
+}
+
+export function TurnItem({
+  turn,
+  toolResults,
+  opened,
+  isLatest,
+  onToggle,
+}: TurnItemProps) {
+  const [hovered, setHovered] = useState(false);
+  const meta = summarize(turn);
+
+  return (
+    <Box style={{ borderBottom: "1px solid #1a1f2e" }}>
+      <UnstyledButton
+        onClick={onToggle}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        style={{
+          display: "block",
+          width: "100%",
+          padding: "7px 12px",
+          background: hovered ? "#12161f" : opened ? "#0d1017" : undefined,
+        }}
+      >
+        <Box style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+          <Text span size="xs" style={{ color: "#4a5568", width: 8, flexShrink: 0 }}>
+            {opened ? "v" : ">"}
+          </Text>
+          <Text
+            span
+            size="xs"
+            fw={700}
+            style={{ color: turn.userMessage ? "#6ea1f7" : "#6b7585", flexShrink: 0 }}
+          >
+            {turn.label}
+          </Text>
+          {isLatest && (
+            <Text span size="xs" fw={600} style={{ color: "#5da87e", flexShrink: 0 }}>
+              latest
+            </Text>
+          )}
+          {meta && (
+            <Text span size="xs" style={{ color: "#4a5568", flexShrink: 0 }}>
+              {meta}
+            </Text>
+          )}
+          {turn.hasError && (
+            <Text span size="xs" fw={600} style={{ color: "#e85d5d", flexShrink: 0 }}>
+              error
+            </Text>
+          )}
+          <Text
+            span
+            size="xs"
+            style={{ color: "#4a5568", marginLeft: "auto", flexShrink: 0 }}
+          >
+            {formatWhen(turn.lastActivityAt)}
+          </Text>
+        </Box>
+        {!opened && turn.preview && (
+          <Text
+            size="xs"
+            style={{
+              color: "#6b7585",
+              marginLeft: 16,
+              marginTop: 1,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {turn.preview}
+          </Text>
+        )}
+      </UnstyledButton>
+      <Collapse in={opened}>
+        <Box pb={6} style={{ background: "#0d1017" }}>
+          {turn.messages.map((msg, i) => (
+            <MessageBubble
+              key={msg.uuid}
+              message={msg}
+              toolResults={toolResults}
+              showHeader={msg.type !== turn.messages[i - 1]?.type}
+            />
+          ))}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}

--- a/orchestrator/frontend/src/lib/groupTurns.ts
+++ b/orchestrator/frontend/src/lib/groupTurns.ts
@@ -1,0 +1,128 @@
+import type {
+  SessionMessage,
+  UserMessage,
+  AssistantMessage,
+  ToolResultContent,
+} from "./sessionTypes";
+
+/**
+ * One exchange: a human prompt and everything the agent did before the next
+ * prompt arrived. Assistant messages that precede the first prompt — a session
+ * picked up mid-flight — form a leading turn with no user message.
+ */
+export interface Turn {
+  /** The uuid of the turn's first message; stable while the turn grows. */
+  id: string;
+  label: string;
+  userMessage: UserMessage | null;
+  /** The turn's messages, oldest first. */
+  messages: SessionMessage[];
+  startedAt: string;
+  lastActivityAt: string;
+  stepCount: number;
+  toolCount: number;
+  hasError: boolean;
+  preview: string;
+}
+
+const PREVIEW_MAX = 160;
+
+export function userText(msg: UserMessage): string {
+  if (typeof msg.message.content === "string") {
+    return msg.message.content;
+  }
+  return msg.message.content
+    .filter((b): b is { type: "text"; text: string } => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+}
+
+/** A user message carrying only tool results is plumbing, not a prompt. */
+function isPrompt(msg: UserMessage): boolean {
+  return userText(msg).trim().length > 0;
+}
+
+function condense(text: string): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length > PREVIEW_MAX ? flat.slice(0, PREVIEW_MAX) + "…" : flat;
+}
+
+function previewOf(group: SessionMessage[], userMessage: UserMessage | null): string {
+  if (userMessage) return condense(userText(userMessage));
+
+  for (const msg of group) {
+    if (msg.type !== "assistant") continue;
+    for (const block of msg.message.content) {
+      if (block.type === "text" && block.text.trim()) return condense(block.text);
+      if (block.type === "tool_use") return block.name;
+    }
+  }
+  return "";
+}
+
+/**
+ * Splits a parsed transcript into turns and collects every tool result by the
+ * id of the call it answers. Results live on the user message that follows the
+ * call, which is not itself a turn boundary, so they are gathered up front.
+ */
+export function groupTurns(messages: SessionMessage[]): {
+  turns: Turn[];
+  toolResults: Map<string, ToolResultContent>;
+} {
+  const toolResults = new Map<string, ToolResultContent>();
+  for (const msg of messages) {
+    if (msg.type === "user" && Array.isArray(msg.message.content)) {
+      for (const block of msg.message.content) {
+        if (block.type === "tool_result") toolResults.set(block.tool_use_id, block);
+      }
+    }
+  }
+
+  const groups: SessionMessage[][] = [];
+  for (const msg of messages) {
+    if (msg.type === "system") continue;
+    if (msg.type === "user" && !isPrompt(msg)) continue;
+
+    if (msg.type === "user" || groups.length === 0) {
+      groups.push([msg]);
+    } else {
+      groups[groups.length - 1].push(msg);
+    }
+  }
+
+  let promptCount = 0;
+  const turns = groups.map((group) => {
+    const first = group[0];
+    const userMessage = first.type === "user" ? (first as UserMessage) : null;
+    if (userMessage) promptCount++;
+
+    const assistants = group.filter(
+      (m): m is AssistantMessage => m.type === "assistant",
+    );
+
+    let toolCount = 0;
+    let hasError = false;
+    for (const msg of assistants) {
+      for (const block of msg.message.content) {
+        if (block.type !== "tool_use") continue;
+        toolCount++;
+        if (toolResults.get(block.id)?.is_error) hasError = true;
+      }
+    }
+
+    return {
+      id: first.uuid,
+      label: userMessage ? `Turn ${promptCount}` : "Session start",
+      userMessage,
+      messages: group,
+      startedAt: first.timestamp,
+      lastActivityAt: group[group.length - 1].timestamp,
+      stepCount: assistants.length,
+      toolCount,
+      hasError,
+      preview: previewOf(group, userMessage),
+    };
+  });
+
+  return { turns, toolResults };
+}

--- a/orchestrator/frontend/src/lib/time.ts
+++ b/orchestrator/frontend/src/lib/time.ts
@@ -1,0 +1,18 @@
+/**
+ * Time alone for today, date and time for anything older — a transcript that
+ * spans days should not show two "04:50 PM" turns as if they were minutes
+ * apart.
+ */
+export function formatWhen(ts: string): string {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return "";
+
+  const time = d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  const now = new Date();
+  const isToday =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+
+  return isToday ? time : `${d.toLocaleDateString()} ${time}`;
+}

--- a/orchestrator/frontend/src/pages/DashboardPage.tsx
+++ b/orchestrator/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   AppShell,
@@ -31,13 +32,39 @@ export function DashboardPage() {
     refetchInterval: 30000,
   });
 
-  const [activeTab, setActiveTab] = useState<string | null>("instances");
-  const [logSource, setLogSource] = useState(ORCHESTRATOR_LOG_SOURCE);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { resource } = useParams();
+
+  const activeTab = location.pathname.split("/")[1] || "instances";
+
+  // The URL drives these while you are on their tab, but the value outlives
+  // the visit: both panels stay mounted across tab switches (Mantine keeps
+  // them), and dropping the selection would release an active takeover and
+  // redirect the log poll behind your back.
   const [sessionSource, setSessionSource] = useState<string | null>(null);
+  const [logSource, setLogSource] = useState(ORCHESTRATOR_LOG_SOURCE);
+  useEffect(() => {
+    if (!resource) return;
+    if (activeTab === "session") setSessionSource(resource);
+    if (activeTab === "logs") setLogSource(resource);
+  }, [activeTab, resource]);
+
+  function changeTab(value: string | null) {
+    if (!value) return;
+    if (value === "session") {
+      navigate(
+        sessionSource ? `/session/${encodeURIComponent(sessionSource)}` : "/session",
+      );
+    } else if (value === "logs") {
+      navigate(`/logs/${encodeURIComponent(logSource)}`);
+    } else {
+      navigate(`/${value}`);
+    }
+  }
 
   function viewSessionFor(containerName: string) {
-    setSessionSource(containerName);
-    setActiveTab("session");
+    navigate(`/session/${encodeURIComponent(containerName)}`);
   }
 
   function formatTime(iso: string) {
@@ -67,7 +94,7 @@ export function DashboardPage() {
 
       <AppShell.Main>
         <Container size="lg">
-          <Tabs value={activeTab} onChange={setActiveTab}>
+          <Tabs value={activeTab} onChange={changeTab}>
             <Tabs.List mb="md">
               <Tabs.Tab value="instances">Instances</Tabs.Tab>
               <Tabs.Tab value="runs">Runs</Tabs.Tab>
@@ -163,7 +190,9 @@ export function DashboardPage() {
               <SessionPanel
                 instances={instances}
                 selected={sessionSource}
-                onSelectedChange={setSessionSource}
+                onSelectedChange={(value) =>
+                  navigate(`/session/${encodeURIComponent(value)}`)
+                }
               />
             </Tabs.Panel>
 
@@ -171,7 +200,9 @@ export function DashboardPage() {
               <LogsPanel
                 instances={instances}
                 selected={logSource}
-                onSelectedChange={setLogSource}
+                onSelectedChange={(value) =>
+                  navigate(`/logs/${encodeURIComponent(value)}`)
+                }
               />
             </Tabs.Panel>
           </Tabs>

--- a/orchestrator/frontend/src/pages/SessionPanel.tsx
+++ b/orchestrator/frontend/src/pages/SessionPanel.tsx
@@ -21,8 +21,9 @@ import {
   Instance,
 } from "../api/client";
 import { parseSession } from "../lib/parseSession";
+import { groupTurns } from "../lib/groupTurns";
 import type { ToolResultContent } from "../lib/sessionTypes";
-import { MessageBubble } from "../components/MessageBubble";
+import { TurnItem } from "../components/TurnItem";
 
 const HEARTBEAT_INTERVAL_MS = 10_000;
 
@@ -40,6 +41,8 @@ export function SessionPanel({
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [takeoverError, setTakeoverError] = useState<string | null>(null);
+  // Every turn starts collapsed; the list is an index you open into.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const controlledRef = useRef<string | null>(null);
 
   const {
@@ -89,6 +92,7 @@ export function SessionPanel({
     if (controlledRef.current && controlledRef.current !== selected) {
       setTakenOver(false);
     }
+    setExpanded(new Set());
   }, [selected]);
 
   async function handleTakeOver() {
@@ -120,33 +124,24 @@ export function SessionPanel({
     }
   }
 
-  const { messages, toolResults } = useMemo(() => {
-    if (!raw) return { messages: [], toolResults: new Map<string, ToolResultContent>() };
-    const parsed = parseSession(raw);
-    const results = new Map<string, ToolResultContent>();
-    for (const msg of parsed) {
-      if (msg.type === "user" && Array.isArray(msg.message.content)) {
-        for (const block of msg.message.content) {
-          if (block.type === "tool_result") {
-            results.set(block.tool_use_id, block);
-          }
-        }
-      }
-    }
-    const displayable = parsed.filter((m) => {
-      if (m.type === "system") return false;
-      if (m.type === "user") {
-        const content = m.message.content;
-        if (Array.isArray(content)) {
-          const hasText = content.some((b) => b.type === "text" && b.text?.trim());
-          if (!hasText) return false;
-        }
-        if (typeof content === "string" && !content.trim()) return false;
-      }
-      return true;
+  const { turns, toolResults } = useMemo(
+    () =>
+      raw
+        ? groupTurns(parseSession(raw))
+        : { turns: [], toolResults: new Map<string, ToolResultContent>() },
+    [raw],
+  );
+
+  const latestTurnId = turns.length > 0 ? turns[turns.length - 1].id : null;
+
+  function toggleTurn(id: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
     });
-    return { messages: displayable, toolResults: results };
-  }, [raw]);
+  }
 
   const options = (instances ?? []).map((inst) => ({
     value: inst.containerName,
@@ -200,19 +195,29 @@ export function SessionPanel({
         <Text c="red">Failed to load session.</Text>
       ) : (
         <>
-          {messages.length === 0 ? (
+          {turns.length === 0 ? (
             <Text c="dimmed">
               No session transcript available yet. This requires the instance's container to
               be running and a Claude session to have started.
             </Text>
           ) : (
-            <ScrollArea h={takenOver ? 480 : 600} bg="dark.8" p="sm">
+            <ScrollArea.Autosize mah={takenOver ? 480 : 600} bg="dark.8">
               <Box>
-                {messages.map((msg) => (
-                  <MessageBubble key={msg.uuid} message={msg} toolResults={toolResults} />
-                ))}
+                {turns
+                  .slice()
+                  .reverse()
+                  .map((turn) => (
+                    <TurnItem
+                      key={turn.id}
+                      turn={turn}
+                      toolResults={toolResults}
+                      opened={expanded.has(turn.id)}
+                      isLatest={turn.id === latestTurnId}
+                      onToggle={() => toggleTurn(turn.id)}
+                    />
+                  ))}
               </Box>
-            </ScrollArea>
+            </ScrollArea.Autosize>
           )}
 
           {takenOver && (

--- a/orchestrator/frontend/vite.config.ts
+++ b/orchestrator/frontend/vite.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { sessionFixture } from "./dev/sessionFixture";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), sessionFixture()],
   build: {
     outDir: "build/dist",
   },


### PR DESCRIPTION
The Session tab rendered a transcript as one flat scroll, so seeing what an agent just did meant scrolling past the opening prompt. Group the transcript into turns — a prompt plus everything the agent did before the next one — and list them newest first, each collapsed to a summary row carrying step and tool counts, an error badge, and a preview of the prompt. Consecutive steps by the same speaker share one header, so a forty-tool turn reads as a list rather than forty repeated name/time lines. Timestamps show the date once a turn is no longer from today.

Each tab is now a route (/instances, /runs, /session/:container, /logs/:source), so the back button moves between tabs instead of leaving the dashboard, and a session link is shareable. Both panels stay mounted across tab switches, so the selected instance outlives the visit: dropping it would release an active takeover and redirect the log poll without the operator noticing. SpaForwardingConfig gains the new paths so a reload serves the app.

Adds a dev-only Vite plugin that serves the dashboard from a Claude Code transcript on disk, so the Session tab can be developed without a running container. Transcripts dropped in dev/fixtures/ are gitignored.