### PR TITLE
Only forward GitLab diff notes on the agent's own merge requests

### DIFF
--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/GitLabEventMapper.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/GitLabEventMapper.java
@@ -222,8 +222,21 @@ public class GitLabEventMapper {
         String type = attrs.path("type").asText("");
         long noteId = attrs.path("id").asLong(0);
 
-        // DiffNote → review comment
+        // DiffNote → review comment. Gated like conversation notes below: a
+        // diff comment on a human's merge request is review conversation among
+        // humans, not something addressed to an agent. Forwarding those gave
+        // any run that happened to correlate a licence to answer and push on
+        // merge requests the bot was never assigned to.
         if ("DiffNote".equals(type)) {
+            if (!isWorkBranch(prc.headBranch()) && !Naming.isArchitectBranch(prc.headBranch())) {
+                log.debug(
+                    "Ignoring diff note on {}!{}: branch '{}' is not an agent work branch",
+                    info.repo(),
+                    prc.number(),
+                    prc.headBranch()
+                );
+                return null;
+            }
             var position = attrs.path("position");
             String path = position.path("new_path").asText("");
             int line = position.path("new_line").asInt(0);

--- a/orchestrator/backend/src/main/resources/workflows/smithy-development.yml
+++ b/orchestrator/backend/src/main/resources/workflows/smithy-development.yml
@@ -400,8 +400,20 @@ state:
 
       pr.review_submitted:
         steps:
+          # Same rule as pr.commented: the agent only works reviews on a pull
+          # request it is assigned to. A review on anyone else's MR is between
+          # humans, however the event found its way here.
+          - uses: pr.isAssigned
+            id: mine
+            with:
+              owner: "{{ vars.owner }}"
+              repo: "{{ vars.repo }}"
+              number: "{{ vars.prNumber }}"
+              assignedActor: "{{ vars.taskActor }}"
+
           - uses: pr.reviewComments
             id: review
+            if: "{{ steps.mine.assigned }}"
             with:
               owner: "{{ vars.owner }}"
               repo: "{{ vars.repo }}"
@@ -411,7 +423,7 @@ state:
               body: "{{ event.reviewBody }}"
 
           - uses: agent.run
-            if: "{{ steps.review.count > 0 }}"
+            if: "{{ steps.mine.assigned and steps.review.count > 0 }}"
             with:
               tools: "{{ vars.buildTools }}"
               template: review_comment.md.j2
@@ -421,12 +433,12 @@ state:
                 comments: "{{ steps.review.comments }}"
 
           - uses: agent.ensureCommitted
-            if: "{{ steps.review.count > 0 }}"
+            if: "{{ steps.mine.assigned and steps.review.count > 0 }}"
             with:
               tools: "{{ vars.buildTools }}"
 
           - uses: git.push
-            if: "{{ steps.review.count > 0 }}"
+            if: "{{ steps.mine.assigned and steps.review.count > 0 }}"
             with:
               tools: "{{ vars.buildTools }}"
 

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/gitlab/GitLabEventMapperTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/gitlab/GitLabEventMapperTest.java
@@ -47,6 +47,37 @@ class GitLabEventMapperTest {
         assertEquals("coordinator", assertInstanceOf(WorkflowEvent.IssueAssigned.class, event).ctx().assignee());
     }
 
+    @Test
+    void aDiffNoteOnAHumansMergeRequestIsNotForTheAgent() throws Exception {
+        // A human MR from a human branch: review conversation among humans.
+        // Forwarding it let a correlated run answer and push on a merge
+        // request the bot was never assigned to.
+        assertNull(mapper().map("Note Hook", json.readTree(diffNote("FVS-1608"))));
+
+        // The agent's own MR still gets its review comments.
+        var own = mapper().map("Note Hook", json.readTree(diffNote("smithy/7-a-thing")));
+        var review = assertInstanceOf(WorkflowEvent.PrReviewComment.class, own);
+        assertEquals(41, review.prc().number());
+        assertEquals("please fix", review.comments().getFirst().body());
+    }
+
+    private static String diffNote(String sourceBranch) {
+        return """
+        {
+          "object_kind": "note",
+          "project": {"path_with_namespace": "acme/app", "git_http_url": "https://gitlab.invalid/acme/app.git",
+                      "web_url": "https://gitlab.invalid/acme/app"},
+          "user": {"username": "b.human"},
+          "object_attributes": {"id": 99, "note": "please fix", "type": "DiffNote", "noteable_type": "MergeRequest",
+                                "discussion_id": "d1",
+                                "position": {"new_path": "src/App.java", "new_line": 12},
+                                "author": {"username": "b.human"}},
+          "merge_request": {"iid": 41, "title": "A change", "description": "", "state": "opened",
+                            "source_branch": "%s", "target_branch": "main"}
+        }
+        """.formatted(sourceBranch);
+    }
+
     private static String opened(String username) {
         return """
         {


### PR DESCRIPTION
## Problem

smithy-bot answers inline review comments and pushes commits on merge requests it is not assigned to (gm-financials!792/!809, gm-frontend-workspace!3230, ecd-care!591 — all human MRs with no assignee or reviewer). Since the bot is assigned nowhere on those MRs, there is nothing to unassign to make it stop.

Every rogue response was to a **DiffNote**. `GitLabEventMapper.mapMrNote` gates regular conversation notes by agent work branch, but forwarded DiffNotes as `pr.review_commented` for *every* merge request in every webhook-connected repository. The GitHub/Forgejo `EventMapper.mapPrComment` already has the work-branch gate on review comments — GitLab's was the only mapper missing it. Once forwarded, any run that matched (branch-correlation matching before b1f887e, or drifted deployed workflow definitions) replied and pushed as the bot.

## Fix

- **Mapper (front door):** DiffNotes on branches that are neither the agent's work branch nor an architect branch are dropped, exactly like conversation notes. This kills the event class regardless of what workflow definitions the deployment runs.
- **Workflow (acting side):** `pr.review_submitted` in `smithy-development.yml` gets the same `pr.isAssigned` guard that `pr.commented` and `push.human` already carry, so no review is acted on unless the bot is actually the MR's assignee.

## Test

- New regression test in `GitLabEventMapperTest`: a DiffNote on a human branch maps to nothing; on a `smithy/...` branch it still becomes a `PrReviewComment`.
- Full backend suite passes.

## Deployment note

The live orchestrator also needs: cancel the runs still camped on the human MRs (cancelled runs ignore events), compare `/config/workflows` against the repo definitions (the committed workflows define no `pr.review_commented` transition, so whatever answers diff notes today is drifted or predates b1f887e), and roll out an image containing this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)