### PR TITLE
Stop headless agents from stalling on permission prompts

### DIFF
--- a/images/claude-task-base/scripts/smithy-init
+++ b/images/claude-task-base/scripts/smithy-init
@@ -77,6 +77,12 @@ if [ -n "$EXTRA_REPOS" ] && [ "$EXTRA_REPOS" != "null" ]; then
   done
 fi
 
+# Scratch area inside the workspace: the agent's file access is scoped to
+# /workspace, so reference clones and downloads belong here, excluded from git.
+mkdir -p /workspace/.smithy/tmp
+grep -qxF ".smithy/tmp/" /workspace/.git/info/exclude 2>/dev/null \
+  || echo ".smithy/tmp/" >> /workspace/.git/info/exclude
+
 mkdir -p /tmp/smithy-labels
 touch /tmp/smithy-init-done
 echo "[smithy] Initialization complete"

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/env/RunEnvironments.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/env/RunEnvironments.java
@@ -112,9 +112,11 @@ public class RunEnvironments {
     public ClaudeSession agent(Run run, List<String> tools) {
         var session = container(run);
         String existing = session.getState().sessionId();
-        return existing != null
+        var agent = existing != null
             ? new ClaudeSession(session, tools, existing, knowledgebaseConfig)
             : new ClaudeSession(session, tools, knowledgebaseConfig);
+        agent.setAddDirs(session.getState().extraDirs());
+        return agent;
     }
 
     /**
@@ -125,7 +127,10 @@ public class RunEnvironments {
      * have from whoever used it last.
      */
     public ClaudeSession newAgent(Run run, List<String> tools) {
-        return new ClaudeSession(container(run), tools, knowledgebaseConfig);
+        var session = container(run);
+        var agent = new ClaudeSession(session, tools, knowledgebaseConfig);
+        agent.setAddDirs(session.getState().extraDirs());
+        return agent;
     }
 
     /** Record the agent's session id so the next transition resumes it. */

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/claude/ClaudeSession.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/claude/ClaudeSession.java
@@ -44,6 +44,7 @@ public class ClaudeSession {
     private final KnowledgebaseConfig knowledgebaseConfig;
     private String contextRepoName;
     private String model;
+    private List<String> addDirs = List.of();
     private boolean started = false;
 
     public ClaudeSession(ContainerSession container, List<String> tools) {
@@ -80,6 +81,16 @@ public class ClaudeSession {
         if (model != null && !model.isBlank()) {
             this.model = model;
         }
+    }
+
+    /**
+     * Directories outside the workspace the agent may read and edit —
+     * a context repo, extra checkouts. Claude scopes file access to its
+     * working directory; anything beyond it must be named per turn or every
+     * access is a permission prompt, which headless runs auto-deny.
+     */
+    public void setAddDirs(List<String> dirs) {
+        this.addDirs = dirs == null ? List.of() : List.copyOf(dirs);
     }
 
     private String model() {
@@ -198,6 +209,11 @@ public class ClaudeSession {
         if (tools != null && !tools.isEmpty()) {
             command.add("--allowedTools");
             command.add(String.join(",", tools));
+        }
+
+        for (String dir : addDirs) {
+            command.add("--add-dir");
+            command.add(dir);
         }
 
         if (outputSchema != null) {

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/ContainerService.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/ContainerService.java
@@ -25,7 +25,11 @@ public class ContainerService {
     private static final String STATE_PATH = "/tmp/smithy-state.json";
     static final ObjectMapper MAPPER = new ObjectMapper()
         .registerModule(new JavaTimeModule())
-        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        // State files may be written by a newer orchestrator than the one
+        // reading them (rollback, adopted container); an unknown field is not
+        // a reason to strand the run.
+        .disable(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
     private static final int INIT_TIMEOUT_SECONDS = 300;
     private static final int INIT_POLL_INTERVAL_MS = 1000;

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/ContainerSession.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/ContainerSession.java
@@ -33,7 +33,11 @@ public class ContainerSession {
     // ── Container init ──────────────────────────────────────
 
     public void initContainer(ContainerConfig config, String initialStage) {
-        cachedState = ContainerState.init(config.workflow(), initialStage);
+        // Extra repos live outside the workspace, so every agent turn must name
+        // them (--add-dir) or their files are unreadable. Recorded in the state
+        // rather than re-derived, so turns after a restart still know them.
+        var extraDirs = config.extraRepos().stream().map(ContainerConfig.ExtraRepo::path).toList();
+        cachedState = ContainerState.init(config.workflow(), initialStage).withExtraDirs(extraDirs);
         service.create(containerName, config);
         service.writeState(containerName, cachedState);
     }

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/dto/ContainerState.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/docker/dto/ContainerState.java
@@ -1,6 +1,7 @@
 package dev.smithyai.orchestrator.service.docker.dto;
 
 import java.time.Instant;
+import java.util.List;
 
 public record ContainerState(
     String sessionId,
@@ -8,37 +9,47 @@ public record ContainerState(
     String workflow,
     int ciRetryCount,
     boolean ciPaused,
-    Instant lastProcessedAt
+    Instant lastProcessedAt,
+    List<String> extraDirs
 ) {
+    public ContainerState {
+        // State written before this field existed has no extraDirs.
+        if (extraDirs == null) extraDirs = List.of();
+    }
+
     public static ContainerState init(String workflow, String stage) {
-        return new ContainerState(null, stage, workflow, 0, false, Instant.now());
+        return new ContainerState(null, stage, workflow, 0, false, Instant.now(), List.of());
     }
 
     public ContainerState withSessionId(String sessionId) {
-        return new ContainerState(sessionId, stage, workflow, ciRetryCount, ciPaused, lastProcessedAt);
+        return new ContainerState(sessionId, stage, workflow, ciRetryCount, ciPaused, lastProcessedAt, extraDirs);
     }
 
     public ContainerState withStage(String stage) {
-        return new ContainerState(sessionId, stage, workflow, ciRetryCount, ciPaused, lastProcessedAt);
+        return new ContainerState(sessionId, stage, workflow, ciRetryCount, ciPaused, lastProcessedAt, extraDirs);
     }
 
     public ContainerState withCiRetryCount(int count) {
-        return new ContainerState(sessionId, stage, workflow, count, ciPaused, lastProcessedAt);
+        return new ContainerState(sessionId, stage, workflow, count, ciPaused, lastProcessedAt, extraDirs);
     }
 
     public ContainerState withCiPaused(boolean paused) {
-        return new ContainerState(sessionId, stage, workflow, ciRetryCount, paused, lastProcessedAt);
+        return new ContainerState(sessionId, stage, workflow, ciRetryCount, paused, lastProcessedAt, extraDirs);
+    }
+
+    public ContainerState withExtraDirs(List<String> extraDirs) {
+        return new ContainerState(sessionId, stage, workflow, ciRetryCount, ciPaused, lastProcessedAt, extraDirs);
     }
 
     public ContainerState incrementCiRetryCount() {
-        return new ContainerState(sessionId, stage, workflow, ciRetryCount + 1, ciPaused, lastProcessedAt);
+        return new ContainerState(sessionId, stage, workflow, ciRetryCount + 1, ciPaused, lastProcessedAt, extraDirs);
     }
 
     public ContainerState resetCi() {
-        return new ContainerState(sessionId, stage, workflow, 0, false, lastProcessedAt);
+        return new ContainerState(sessionId, stage, workflow, 0, false, lastProcessedAt, extraDirs);
     }
 
     public ContainerState touch() {
-        return new ContainerState(sessionId, stage, workflow, ciRetryCount, ciPaused, Instant.now());
+        return new ContainerState(sessionId, stage, workflow, ciRetryCount, ciPaused, Instant.now(), extraDirs);
     }
 }

--- a/orchestrator/backend/src/main/resources/prompts/building.md.j2
+++ b/orchestrator/backend/src/main/resources/prompts/building.md.j2
@@ -16,6 +16,10 @@ The following files were attached to this issue and are available in the contain
 You may read these files directly or copy them into the repository if needed.
 {% endif %}
 
+## How you are running
+
+You work unattended: a tool call outside this turn's allowlist is denied automatically, and nobody can approve the prompt — never ask for permissions, mode switches, or prompt approvals. You have write access to the workspace for this turn. If you need another repository purely as reference, clone it inside the workspace at `.smithy/tmp/` (it is excluded from git); paths outside the workspace are not readable. If something outside your reach genuinely blocks a part of the plan, implement what you can and state plainly in your final report what was blocked and why.
+
 ## Instructions
 
 1. Read the plan file carefully.

--- a/orchestrator/backend/src/main/resources/prompts/refinement.md.j2
+++ b/orchestrator/backend/src/main/resources/prompts/refinement.md.j2
@@ -16,6 +16,10 @@ The following files were attached to this issue and are available in the contain
 You may read these files directly or copy them into the repository if needed.
 {% endif %}
 
+## How you are running
+
+You work unattended: no one is at a terminal, and a tool call outside this turn's allowlist is denied automatically — a denial is stage policy, not a prompt someone can approve. Never ask for permissions to be granted, modes to be switched, or prompts to be accepted. This planning turn is deliberately read-only; implementation runs in a later turn, with write access, once a human approves the plan. If something you need is missing — a decision only a human can make — record it in the plan or its Open Questions instead of requesting access. If you need another repository purely as reference, clone it inside the workspace at `.smithy/tmp/` (it is excluded from git); paths outside the workspace are not readable.
+
 ## Instructions
 
 Explore the codebase and create a plan for this issue. Match the plan's length to the task: a small issue with clear instructions needs only a few lines — the approach in a sentence or two, the files you expect to touch, and the tests. Reserve detailed sections for work that genuinely spans components or carries real design decisions; a reviewer should be able to approve a small plan in one read.

--- a/orchestrator/backend/src/main/resources/prompts/refinement_comment.md.j2
+++ b/orchestrator/backend/src/main/resources/prompts/refinement_comment.md.j2
@@ -16,6 +16,15 @@ The following files were attached to this issue and are available in the contain
 You may read these files directly or copy them into the repository if needed.
 {% endif %}
 
+## How you are running
+
+You work unattended: a tool call outside this turn's allowlist is denied automatically,
+and nobody can approve the prompt — never ask for permissions or mode switches. In this
+turn you may read the repository and modify only the plan file; code changes happen in a
+later turn, once the plan is approved. If the feedback asks you to implement something
+now, fold the request into the plan and say in the plan that implementation starts on
+approval.
+
 ## Instructions
 
 Read the current plan at `{{ plan_file_path }}`, apply this feedback, and write the

--- a/orchestrator/backend/src/main/resources/workflows/smithy-development.yml
+++ b/orchestrator/backend/src/main/resources/workflows/smithy-development.yml
@@ -199,9 +199,21 @@ state:
               repo: "{{ vars.repo }}"
               issue: "{{ vars.issueRef }}"
 
+          # Read tools plus writes scoped to the plan directory: the template
+          # asks the agent to update the plan file, so the tool it is told to
+          # use must actually be allowed — a headless turn cannot approve the
+          # prompt an off-allowlist Write triggers. Code stays read-only until
+          # the plan is approved.
           - uses: agent.run
             with:
-              tools: "{{ vars.refineTools }}"
+              tools:
+                - Read
+                - Glob
+                - Grep
+                - Bash
+                - WebFetch
+                - "Edit({{ vars.planDir }}/**)"
+                - "Write({{ vars.planDir }}/**)"
               template: refinement_comment.md.j2
               vars:
                 issue_ref: "{{ vars.issueRef }}"


### PR DESCRIPTION
## Problem

While working FVS-1799 the frontend agent replied: *"I'm blocked on writes — every file edit, directory creation, and branch command needs your approval, in both repos"* and asked for `/permissions` changes. In `claude -p` every permission prompt is auto-denied and nobody can approve anything, so any mismatch between a turn's instructions and its allowlist reads to the model as a human-approvable block — and the story stalls while it waits for an approver that doesn't exist.

## Gaps closed

1. **Refine-comment turn told to Write without the Write tool.** `refinement_comment.md.j2` says "write the updated plan back using the Write tool", but the turn ran with `refineTools` (no Edit/Write). It now gets `Edit({{ vars.planDir }}/**)` / `Write({{ vars.planDir }}/**)` alongside the read tools — the plan file is editable, the code is not, until approval.
2. **No `--add-dir`.** Claude scopes file access to its working directory; extra repos cloned beside `/workspace` (e.g. a `/context-repo`) were unreadable in every turn. `container.init` now records the extra-repo paths in the container state, and `RunEnvironments` passes them to every `ClaudeSession` as `--add-dir` — takeover sessions included. The state mapper also stops failing on unknown fields so a rolled-back orchestrator can read newer state files.
3. **The agent didn't know it runs unattended.** `refinement`, `refinement_comment` and `building` templates now carry a short "How you are running" section: denials are stage policy, never ask for permission grants or mode switches, record genuine blockers in the plan/report, and put reference clones in the git-excluded `/workspace/.smithy/tmp` (pre-created by `smithy-init`) because paths outside the workspace are out of scope.

## Test

Full backend suite passes.

## Deployment note

The `smithy-init` change ships in **claude-task-base** (and its derivatives) — agents pick it up on their next container creation; existing containers keep the old script harmlessly. The rest ships in the orchestrator image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)