### PR TITLE
Stop takeover messages colliding with in-flight agent turns

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -24,6 +24,8 @@ agent:
     model: claude-opus-5
     oauthToken: {env: CLAUDE_CODE_OAUTH_TOKEN}
     apiKey: {env: ANTHROPIC_API_KEY}
+    turnTimeout: 60m          # budget for one agent turn; overrunning turns are killed
+    takeoverTimeout: 5m       # budget for a turn a human drove from the dashboard
 
 auth:
   admin:
@@ -77,6 +79,40 @@ volumes:
   - ./config/workflows:/config/workflows:ro
   - orchestrator-data:/data
 ```
+
+## Agent turn timeout
+
+`agent.claude.turnTimeout` caps the wall-clock time one agent turn may take —
+`45m`, `2h`, `900s` and `PT45M` are all accepted, and the built-in default is
+60 minutes. The deadline is enforced inside the task container, so an overrunning
+turn is actually killed rather than left running after the orchestrator stops
+waiting for it.
+
+A turn that hits the cap fails its step with:
+
+```
+Claude turn on <container> (session=<id>) exceeded its 60m budget and was killed.
+```
+
+Raise the value for workflows whose build stage legitimately runs longer, or split
+the step into smaller turns. Note that the budget is per turn, not per run: a
+workflow with five turns can run for five times this long.
+
+`agent.claude.takeoverTimeout` (default 5 minutes) is the budget for a turn a
+person drove from the dashboard. It is deliberately much shorter: someone is
+waiting on that reply in a browser, so an unanswered request is a hung dashboard
+rather than a long job.
+
+A run's turns all share one agent session, and that session cannot take two
+concurrent processes. Taking control does not interrupt a turn that is already
+running — the lease stops new events being dispatched, not work in flight — so a
+message sent mid-turn is refused with a 409 and
+
+```
+The agent on run <id> is in the middle of a turn.
+```
+
+rather than queued behind it. Wait for the turn to land, or stop the run.
 
 ## Secrets
 

--- a/examples/demo/config/orchestrator.yml
+++ b/examples/demo/config/orchestrator.yml
@@ -17,6 +17,8 @@ agent:
     model: claude-opus-5
     oauthToken: {env: CLAUDE_CODE_OAUTH_TOKEN}
     apiKey: {env: ANTHROPIC_API_KEY}
+    turnTimeout: 60m          # budget for one agent turn; overrunning turns are killed
+    takeoverTimeout: 5m       # budget for a turn a human drove from the dashboard
 
 auth:
   admin:

--- a/examples/full/config/orchestrator-jira-gitlab.yml
+++ b/examples/full/config/orchestrator-jira-gitlab.yml
@@ -13,6 +13,8 @@ agent:
     model: claude-opus-5
     oauthToken: {env: CLAUDE_CODE_OAUTH_TOKEN}
     apiKey: {env: ANTHROPIC_API_KEY}
+    turnTimeout: 60m          # budget for one agent turn; overrunning turns are killed
+    takeoverTimeout: 5m       # budget for a turn a human drove from the dashboard
 auth:
   admin:
     passwordHash: {env: ADMIN_PASSWORD_HASH}

--- a/examples/full/config/orchestrator.yml
+++ b/examples/full/config/orchestrator.yml
@@ -17,6 +17,8 @@ agent:
     model: claude-opus-5
     oauthToken: {env: CLAUDE_CODE_OAUTH_TOKEN}
     apiKey: {env: ANTHROPIC_API_KEY}
+    turnTimeout: 60m          # budget for one agent turn; overrunning turns are killed
+    takeoverTimeout: 5m       # budget for a turn a human drove from the dashboard
 
 auth:
   admin:

--- a/examples/github-local/orchestrator.yml
+++ b/examples/github-local/orchestrator.yml
@@ -12,6 +12,8 @@ agent:
   claude:
     model: claude-opus-5
     oauthToken: {env: CLAUDE_CODE_OAUTH_TOKEN}
+    turnTimeout: 60m          # budget for one agent turn; overrunning turns are killed
+    takeoverTimeout: 5m       # budget for a turn a human drove from the dashboard
 auth:
   admin:
     passwordHash: {env: ADMIN_PASSWORD_HASH}

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/AgentConfig.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/AgentConfig.java
@@ -1,5 +1,68 @@
 package dev.smithyai.orchestrator.config;
 
+import java.time.Duration;
+import java.util.Optional;
+
 public record AgentConfig(ClaudeAgentConfig claude) {
-    public record ClaudeAgentConfig(String model, SecretRef oauthToken, SecretRef apiKey) {}
+    public record ClaudeAgentConfig(
+        String model,
+        SecretRef oauthToken,
+        SecretRef apiKey,
+        String turnTimeout,
+        String takeoverTimeout
+    ) {
+        /**
+         * Wall-clock budget for one agent turn, or empty to keep the built-in
+         * default. Accepts {@code 45m}, {@code 2h}, {@code 900s} or ISO-8601
+         * ({@code PT45M}).
+         */
+        public Optional<Duration> resolvedTurnTimeout() {
+            return parse(turnTimeout, "turnTimeout");
+        }
+
+        /**
+         * Budget for a turn a human drove from the dashboard. Separate because a
+         * person is waiting on the reply in a browser, so it wants to be minutes
+         * rather than the tens of minutes a build turn is allowed.
+         */
+        public Optional<Duration> resolvedTakeoverTimeout() {
+            return parse(takeoverTimeout, "takeoverTimeout");
+        }
+
+        private static Optional<Duration> parse(String raw, String key) {
+            if (raw == null || raw.isBlank()) return Optional.empty();
+            return Optional.of(parseTurnTimeout(raw, key));
+        }
+
+        private static Duration parseTurnTimeout(String raw, String key) {
+            Duration parsed;
+            try {
+                String value = raw.strip();
+                if (value.regionMatches(true, 0, "P", 0, 1)) {
+                    parsed = Duration.parse(value);
+                } else {
+                    char unit = value.charAt(value.length() - 1);
+                    long amount = Long.parseLong(value.substring(0, value.length() - 1).strip());
+                    parsed = switch (Character.toLowerCase(unit)) {
+                        case 's' -> Duration.ofSeconds(amount);
+                        case 'm' -> Duration.ofMinutes(amount);
+                        case 'h' -> Duration.ofHours(amount);
+                        default -> throw new IllegalArgumentException("unknown unit '" + unit + "'");
+                    };
+                }
+            } catch (RuntimeException e) {
+                throw new IllegalStateException(
+                    "agent.claude.%s is not a duration: '%s' (expected e.g. 45m, 2h, 900s or PT45M)".formatted(
+                        key,
+                        raw
+                    ),
+                    e
+                );
+            }
+            if (parsed.isZero() || parsed.isNegative()) {
+                throw new IllegalStateException("agent.claude.%s must be positive, got '%s'".formatted(key, raw));
+            }
+            return parsed;
+        }
+    }
 }

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/ConfigLoader.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/ConfigLoader.java
@@ -30,11 +30,13 @@ public class ConfigLoader {
             ClaudeConfig claude = resolvedClaudeConfig();
             claude.validate();
             ClaudeSession.configureDefaultModel(claude.resolvedModel());
+            config.agent().claude().resolvedTurnTimeout().ifPresent(ClaudeSession::configureTurnTimeout);
             log.info(
-                "Loaded orchestrator config (connectors={}, defaultVcs={}, model={})",
+                "Loaded orchestrator config (connectors={}, defaultVcs={}, model={}, turnTimeout={})",
                 config.connectors().keySet(),
                 config.defaults().vcs(),
-                claude.resolvedModel()
+                claude.resolvedModel(),
+                ClaudeSession.turnTimeout()
             );
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to parse orchestrator config", e);
@@ -70,6 +72,12 @@ public class ConfigLoader {
     @Bean
     public ClaudeConfig claudeConfig() {
         return resolvedClaudeConfig();
+    }
+
+    /** The unresolved agent block, for the settings that are not secrets. */
+    @Bean
+    public AgentConfig.ClaudeAgentConfig claudeAgentConfig() {
+        return config.agent().claude();
     }
 
     private ClaudeConfig resolvedClaudeConfig() {

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/AgentBusyException.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/AgentBusyException.java
@@ -1,0 +1,20 @@
+package dev.smithyai.orchestrator.runtime.engine;
+
+/**
+ * A turn was asked for while the run's agent session was already in one.
+ *
+ * <p>Raised instead of waiting: the session cannot take a second concurrent
+ * process, and a person typing in the dashboard needs to hear that now rather
+ * than watch a request hang until the turn budget runs out.
+ */
+public class AgentBusyException extends RuntimeException {
+
+    public AgentBusyException(String runId) {
+        super(
+            (
+                "The agent on run %s is in the middle of a turn. Its session cannot take a second message " +
+                "until that finishes — wait for the current turn, or stop the run."
+            ).formatted(runId)
+        );
+    }
+}

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunEngine.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunEngine.java
@@ -42,6 +42,7 @@ public class RunEngine implements SignalDelivery {
     private final RunEnvironments environments;
     private final RepositoryWorkflowLoader repositoryWorkflows;
     private final EventDebouncer debouncer;
+    private final RunLocks locks;
 
     public RunEngine(
         WorkflowRegistry registry,
@@ -50,7 +51,8 @@ public class RunEngine implements SignalDelivery {
         RunStore store,
         RunEnvironments environments,
         RepositoryWorkflowLoader repositoryWorkflows,
-        EventDebouncer debouncer
+        EventDebouncer debouncer,
+        RunLocks locks
     ) {
         this.registry = registry;
         this.router = router;
@@ -59,6 +61,7 @@ public class RunEngine implements SignalDelivery {
         this.environments = environments;
         this.repositoryWorkflows = repositoryWorkflows;
         this.debouncer = debouncer;
+        this.locks = locks;
     }
 
     /** What an event did, for logs and for the tests that assert on routing. */
@@ -369,20 +372,13 @@ public class RunEngine implements SignalDelivery {
      * does not leave a lock behind if the process dies.
      */
     private Outcome dispatch(WorkflowDefinition definition, Run run, WorkflowEvent event) {
-        synchronized (lockFor(run.id())) {
+        return locks.inRun(run.id(), () -> {
             // Re-read inside the lock. The run was resolved before it, so another
             // event may have moved it since — and acting on the state it used to
             // be in runs the wrong transition.
             var current = store.find(run.id()).orElse(run);
             return dispatchSerially(definition, current, event);
-        }
-    }
-
-    private final java.util.concurrent.ConcurrentMap<String, Object> locks =
-        new java.util.concurrent.ConcurrentHashMap<>();
-
-    private Object lockFor(String runId) {
-        return locks.computeIfAbsent(runId, id -> new Object());
+        });
     }
 
     private Outcome dispatchSerially(WorkflowDefinition definition, Run run, WorkflowEvent event) {

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunLocks.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunLocks.java
@@ -1,0 +1,73 @@
+package dev.smithyai.orchestrator.runtime.engine;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+
+/**
+ * One agent turn at a time per run.
+ *
+ * <p>A run's turns all talk to one Claude session in one container, and the CLI
+ * is not built to have two processes resuming the same session at once. Two
+ * webhooks arriving together are one way that happens; a human taking over
+ * mid-turn and typing into the same session is the other. Both go through here,
+ * which is the point — a guard the takeover path did not share was a guard the
+ * takeover path did not have.
+ *
+ * <p>In-process is enough while one orchestrator owns the store, and unlike a
+ * row in a table it leaves nothing behind if the process dies.
+ */
+@Component
+public class RunLocks {
+
+    private final ConcurrentMap<String, ReentrantLock> locks = new ConcurrentHashMap<>();
+
+    /** Run {@code work} with the run to itself, waiting however long that takes. */
+    public <T> T inRun(String runId, Supplier<T> work) {
+        var lock = lockFor(runId);
+        lock.lock();
+        try {
+            return work.get();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * The same, but give up after {@code wait} instead of queueing.
+     *
+     * <p>Empty means someone else is mid-turn. A caller with a person waiting on
+     * the other end wants to say so now, not in forty minutes.
+     */
+    public <T> Optional<T> tryInRun(String runId, Duration wait, Supplier<T> work) {
+        var lock = lockFor(runId);
+        try {
+            if (!lock.tryLock(wait.toMillis(), TimeUnit.MILLISECONDS)) return Optional.empty();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return Optional.empty();
+        }
+        try {
+            return Optional.ofNullable(work.get());
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Whether a turn is in flight for this run. */
+    public boolean isBusy(String runId) {
+        var lock = locks.get(runId);
+        return lock != null && lock.isLocked();
+    }
+
+    private ReentrantLock lockFor(String runId) {
+        // Reentrant because the monitor this replaced was: a step that dispatches
+        // an event for its own run must not deadlock against itself.
+        return locks.computeIfAbsent(runId, id -> new ReentrantLock());
+    }
+}

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunTakeover.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunTakeover.java
@@ -1,5 +1,6 @@
 package dev.smithyai.orchestrator.runtime.engine;
 
+import dev.smithyai.orchestrator.config.AgentConfig.ClaudeAgentConfig;
 import dev.smithyai.orchestrator.runtime.env.RunEnvironments;
 import dev.smithyai.orchestrator.runtime.store.Run;
 import dev.smithyai.orchestrator.runtime.store.RunLease;
@@ -30,12 +31,29 @@ public class RunTakeover {
 
     private static final Duration TTL = Duration.ofSeconds(30);
 
+    /**
+     * How long a human message waits for an in-flight turn before giving up. Kept
+     * short on purpose: the answer "the agent is busy" is useful immediately and
+     * useless after a queue.
+     */
+    private static final Duration BUSY_WAIT = Duration.ofSeconds(5);
+
+    /**
+     * Budget for a turn a person is waiting on in a browser. Much shorter than a
+     * build turn's — an unanswered request is a hung dashboard, not a long job.
+     */
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(5);
+
     private final RunStore store;
     private final RunEnvironments environments;
+    private final RunLocks locks;
+    private final Duration turnTimeout;
 
-    public RunTakeover(RunStore store, RunEnvironments environments) {
+    public RunTakeover(RunStore store, RunEnvironments environments, RunLocks locks, ClaudeAgentConfig claude) {
         this.store = store;
         this.environments = environments;
+        this.locks = locks;
+        this.turnTimeout = claude == null ? DEFAULT_TIMEOUT : claude.resolvedTakeoverTimeout().orElse(DEFAULT_TIMEOUT);
     }
 
     public boolean isHeld(String runId) {
@@ -66,14 +84,32 @@ public class RunTakeover {
      *
      * <p>Renews the lease first: a long exchange should not lapse halfway
      * through because the reply took longer than the heartbeat interval.
+     *
+     * <p>Takes the run's turn lock, because holding the lease is not the same as
+     * the session being free. The lease stops <em>new</em> events being
+     * dispatched; a turn that was already running when someone took over keeps
+     * running, and firing a second {@code claude --resume} at the same session
+     * gets a message that never lands and a request that hangs until the budget
+     * runs out. So this reports the collision instead of joining it.
+     *
+     * @throws AgentBusyException if a turn is already in flight for this run
      */
     public String send(Run run, String text, List<String> tools) {
         heartbeat(run.id());
-        var container = environments.container(run);
-        var agent = environments.agent(run, tools);
-        String reply = agent.send(text);
-        environments.rememberAgentSession(container, agent);
-        store.appendEvent(run.id(), "takeover.message", Map.of("length", text.length()));
-        return reply;
+        return locks
+            .tryInRun(run.id(), BUSY_WAIT, () -> {
+                var container = environments.container(run);
+                var agent = environments.agent(run, tools);
+                agent.setTurnTimeout(turnTimeout);
+                String reply = agent.send(text);
+                environments.rememberAgentSession(container, agent);
+                store.appendEvent(run.id(), "takeover.message", Map.of("length", text.length()));
+                return reply == null ? "" : reply;
+            })
+            .orElseThrow(() -> {
+                store.appendEvent(run.id(), "takeover.message.busy", Map.of("length", text.length()));
+                log.info("Held a takeover message on run {}: a turn is already in flight", run.id());
+                return new AgentBusyException(run.id());
+            });
     }
 }

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/claude/ClaudeSession.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/claude/ClaudeSession.java
@@ -20,9 +20,44 @@ import lombok.extern.slf4j.Slf4j;
 public class ClaudeSession {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final Duration TIMEOUT = Duration.ofMinutes(30);
     private static final String CLAUDE_BINARY = "/usr/bin/claude";
     private static final String PLANS_DIR = "/root/.claude/plans";
+
+    /**
+     * Wall-clock budget for one agent turn. A build turn on a real repository
+     * works for tens of minutes, so this is deliberately generous; override it
+     * with agent.claude.turnTimeout when a workflow needs longer still.
+     */
+    private static final Duration DEFAULT_TURN_TIMEOUT = Duration.ofMinutes(60);
+
+    /**
+     * Head-room on top of the budget before the local docker client stops
+     * waiting. The deadline is enforced inside the container, so the client only
+     * has to outlive it — this is a backstop for a wedged daemon, not the limit.
+     */
+    private static final Duration CLIENT_GRACE = Duration.ofSeconds(60);
+
+    /** Grace between SIGTERM and SIGKILL for a turn that overran. */
+    private static final String KILL_AFTER = "10s";
+
+    /** GNU timeout's exit status for a command it had to stop. */
+    private static final int TIMEOUT_EXIT_CODE = 124;
+
+    private static volatile Duration turnTimeout = DEFAULT_TURN_TIMEOUT;
+
+    /**
+     * Set once at startup from agent.claude.turnTimeout by
+     * {@link dev.smithyai.orchestrator.config.ConfigLoader}.
+     */
+    public static void configureTurnTimeout(Duration timeout) {
+        if (timeout != null && !timeout.isZero() && !timeout.isNegative()) {
+            turnTimeout = timeout;
+        }
+    }
+
+    public static Duration turnTimeout() {
+        return turnTimeout;
+    }
 
     /**
      * Model used when callers don't pass one explicitly. Set once at startup from
@@ -46,6 +81,7 @@ public class ClaudeSession {
     private String model;
     private List<String> addDirs = List.of();
     private boolean started = false;
+    private Duration sessionTurnTimeout;
 
     public ClaudeSession(ContainerSession container, List<String> tools) {
         this(container, tools, null, null);
@@ -93,8 +129,23 @@ public class ClaudeSession {
         this.addDirs = dirs == null ? List.of() : List.copyOf(dirs);
     }
 
+    /**
+     * Give this session's turns a different budget from the configured one — a
+     * turn someone is waiting on in a browser is not a build turn. Null or
+     * non-positive keeps the configured budget.
+     */
+    public void setTurnTimeout(Duration timeout) {
+        if (timeout != null && !timeout.isZero() && !timeout.isNegative()) {
+            this.sessionTurnTimeout = timeout;
+        }
+    }
+
     private String model() {
         return model != null ? model : defaultModel;
+    }
+
+    private Duration budget() {
+        return sessionTurnTimeout != null ? sessionTurnTimeout : turnTimeout;
     }
 
     public void startPlan(String prompt) {
@@ -186,7 +237,16 @@ public class ClaudeSession {
     // ── Internal ─────────────────────────────────────────────
 
     private String execute(String prompt, String model, String permissionMode, boolean resume, String outputSchema) {
+        Duration budget = budget();
+
         List<String> command = new ArrayList<>();
+        // Bound the turn inside the container rather than only here. Killing the
+        // local `docker exec` leaves the CLI running: the daemon does not stop an
+        // exec whose client went away, and the orphan keeps working and keeps
+        // writing the session transcript that the next turn resumes.
+        command.add("timeout");
+        command.add("--kill-after=" + KILL_AFTER);
+        command.add(budget.toSeconds() + "s");
         command.add(CLAUDE_BINARY);
         command.add("-p");
         command.add("-"); // read prompt from stdin
@@ -235,7 +295,17 @@ public class ClaudeSession {
         }
 
         log.debug("Executing Claude prompt on {} (session={})", container.getContainerName(), sessionId);
-        ExecResult result = container.exec(command, TIMEOUT, prompt);
+        ExecResult result = container.exec(command, budget.plus(CLIENT_GRACE), prompt);
+
+        if (result.exitCode() == TIMEOUT_EXIT_CODE) {
+            log.warn(
+                "Claude turn timed out after {} on {} (session={})",
+                budget,
+                container.getContainerName(),
+                sessionId
+            );
+            throw new ClaudeTimeoutException(budget, container.getContainerName(), sessionId, result.stdout());
+        }
 
         if (result.exitCode() != 0) {
             log.warn(

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/claude/ClaudeTimeoutException.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/claude/ClaudeTimeoutException.java
@@ -1,0 +1,41 @@
+package dev.smithyai.orchestrator.service.claude;
+
+import java.time.Duration;
+import lombok.Getter;
+
+/**
+ * An agent turn that ran past its budget and was killed.
+ *
+ * <p>Separate from a generic process failure because the remedy is different:
+ * neither the prompt nor the container is broken, the work simply did not fit in
+ * the time allowed. Extends {@link IllegalStateException} so anything written
+ * against the failure this replaced still catches it.
+ */
+@Getter
+public class ClaudeTimeoutException extends IllegalStateException {
+
+    private final Duration budget;
+    private final String containerName;
+    private final String sessionId;
+
+    /** Whatever the CLI had written before it was killed — usually empty. */
+    private final String partialOutput;
+
+    public ClaudeTimeoutException(Duration budget, String containerName, String sessionId, String partialOutput) {
+        super(
+            (
+                "Claude turn on %s (session=%s) exceeded its %s budget and was killed. " +
+                "Raise agent.claude.turnTimeout in orchestrator.yml, or split the step into smaller turns."
+            ).formatted(containerName, sessionId, human(budget))
+        );
+        this.budget = budget;
+        this.containerName = containerName;
+        this.sessionId = sessionId;
+        this.partialOutput = partialOutput == null ? "" : partialOutput;
+    }
+
+    private static String human(Duration budget) {
+        long minutes = budget.toMinutes();
+        return minutes > 0 ? minutes + "m" : budget.toSeconds() + "s";
+    }
+}

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/DashboardController.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/DashboardController.java
@@ -1,5 +1,6 @@
 package dev.smithyai.orchestrator.web;
 
+import dev.smithyai.orchestrator.runtime.engine.AgentBusyException;
 import dev.smithyai.orchestrator.runtime.engine.RunEngine;
 import dev.smithyai.orchestrator.runtime.engine.RunTakeover;
 import dev.smithyai.orchestrator.runtime.env.RunEnvironments;
@@ -8,6 +9,7 @@ import dev.smithyai.orchestrator.runtime.store.RunRecorder;
 import dev.smithyai.orchestrator.runtime.store.RunStatus;
 import dev.smithyai.orchestrator.runtime.store.RunStore;
 import dev.smithyai.orchestrator.runtime.store.RunWait;
+import dev.smithyai.orchestrator.service.claude.ClaudeTimeoutException;
 import dev.smithyai.orchestrator.service.docker.ContainerService;
 import dev.smithyai.orchestrator.service.metrics.MetricsRecorder;
 import dev.smithyai.orchestrator.web.dto.InstanceDto;
@@ -309,6 +311,13 @@ public class DashboardController {
         if (!takeover.isHeld(run.get().id())) {
             return ResponseEntity.status(409).body("No active takeover for this run");
         }
-        return ResponseEntity.ok(takeover.send(run.get(), request.text(), List.of()));
+        try {
+            return ResponseEntity.ok(takeover.send(run.get(), request.text(), List.of()));
+        } catch (AgentBusyException e) {
+            // 409 rather than 500: nothing is broken, the session is occupied.
+            return ResponseEntity.status(409).body(e.getMessage());
+        } catch (ClaudeTimeoutException e) {
+            return ResponseEntity.status(504).body(e.getMessage());
+        }
     }
 }

--- a/orchestrator/backend/src/main/resources/orchestrator.yml
+++ b/orchestrator/backend/src/main/resources/orchestrator.yml
@@ -19,6 +19,12 @@ agent:
       env: CLAUDE_CODE_OAUTH_TOKEN
     apiKey:
       env: ANTHROPIC_API_KEY
+    # Wall-clock budget for a single agent turn (45m, 2h, 900s or PT45M).
+    # A turn that overruns is killed inside its container and the step fails.
+    turnTimeout: 60m
+    # Budget for a turn a human drove from the dashboard, where someone is
+    # waiting on the reply in a browser rather than on a build.
+    takeoverTimeout: 5m
 
 auth:
   admin:

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/FeatureCoordinatorTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/FeatureCoordinatorTest.java
@@ -284,7 +284,8 @@ class FeatureCoordinatorTest {
             store,
             environments,
             null,
-            new EventDebouncer()
+            new EventDebouncer(),
+            new RunLocks()
         );
     }
 

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/RepositoryWorkflowTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/RepositoryWorkflowTest.java
@@ -115,7 +115,8 @@ class RepositoryWorkflowTest {
             store,
             new RunEnvironments(store, null, null),
             new RepositoryWorkflowLoader(vcs, parser),
-            new EventDebouncer()
+            new EventDebouncer(),
+            new RunLocks()
         );
     }
 

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/RunEngineTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/RunEngineTest.java
@@ -157,7 +157,8 @@ class RunEngineTest {
             store,
             new RunEnvironments(store, null, null),
             null,
-            new EventDebouncer()
+            new EventDebouncer(),
+            new RunLocks()
         );
     }
 
@@ -363,9 +364,7 @@ class RunEngineTest {
 
         // A human opened MR 42 from the run's work branch. Its comments are
         // theirs: the run must not answer them just because the branch matches.
-        var strangers = engine
-            .handle(prComment(42, "please ignore this MR"))
-            .getFirst();
+        var strangers = engine.handle(prComment(42, "please ignore this MR")).getFirst();
         assertFalse(strangers.handled());
         assertNull(store.find(started.runId()).orElseThrow().vars().get("lastPrComment"));
 

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/engine/RunTakeoverConcurrencyTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/engine/RunTakeoverConcurrencyTest.java
@@ -1,0 +1,147 @@
+package dev.smithyai.orchestrator.runtime.engine;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import dev.smithyai.orchestrator.config.AgentConfig.ClaudeAgentConfig;
+import dev.smithyai.orchestrator.runtime.env.RunEnvironments;
+import dev.smithyai.orchestrator.runtime.store.Run;
+import dev.smithyai.orchestrator.runtime.store.RunStatus;
+import dev.smithyai.orchestrator.runtime.store.RunStore;
+import dev.smithyai.orchestrator.service.claude.ClaudeSession;
+import dev.smithyai.orchestrator.service.docker.ContainerSession;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A human message must not land on a session that is already mid-turn.
+ *
+ * <p>Holding the takeover lease is not the same as the session being free: the
+ * lease stops new events being dispatched, while a turn that was already running
+ * when someone took over keeps running. Firing a second {@code claude --resume}
+ * at that session produced a message that never landed and a request that hung
+ * until the turn budget ran out, which is what this pins down.
+ */
+class RunTakeoverConcurrencyTest {
+
+    private static final Run RUN = new Run(
+        "run-1",
+        "smithy",
+        "1",
+        RunStatus.RUNNING,
+        "building",
+        Map.of(),
+        null,
+        null,
+        Instant.now(),
+        Instant.now(),
+        null
+    );
+
+    private RunStore store;
+    private RunEnvironments environments;
+    private RunLocks locks;
+    private RunTakeover takeover;
+
+    @BeforeEach
+    void setUp() {
+        store = mock(RunStore.class);
+        environments = mock(RunEnvironments.class);
+        locks = new RunLocks();
+
+        when(store.isLeased(any())).thenReturn(true);
+        when(store.acquireLease(any(), any(), any())).thenReturn(Optional.of(Instant.now().plusSeconds(30)));
+
+        takeover = new RunTakeover(store, environments, locks, agentConfig("5m"));
+    }
+
+    @Test
+    void aMessageSentWhileATurnIsInFlightIsRefusedRatherThanQueued() throws Exception {
+        var turnStarted = new CountDownLatch(1);
+        var releaseTurn = new CountDownLatch(1);
+
+        // Stand in for an engine turn: it holds the run's lock and works.
+        var engineTurn = Thread.ofPlatform().start(() ->
+            locks.inRun(RUN.id(), () -> {
+                turnStarted.countDown();
+                try {
+                    releaseTurn.await(10, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return null;
+            })
+        );
+
+        assertTrue(turnStarted.await(5, TimeUnit.SECONDS), "the stand-in turn never started");
+        try {
+            long began = System.nanoTime();
+            var thrown = assertThrows(AgentBusyException.class, () -> takeover.send(RUN, "hello", List.of()));
+            var waited = Duration.ofNanos(System.nanoTime() - began);
+
+            assertTrue(thrown.getMessage().contains("run-1"), thrown.getMessage());
+            // The point is that it gave up quickly rather than blocking on the turn.
+            assertTrue(waited.toSeconds() < 8, "waited " + waited + " before refusing");
+            // And no second session was ever opened on the container.
+            verify(environments, never()).agent(any(), any());
+        } finally {
+            releaseTurn.countDown();
+            engineTurn.join(5000);
+        }
+    }
+
+    @Test
+    void aMessageOnAFreeSessionGoesThroughOnTheTakeoverBudget() {
+        var container = mock(ContainerSession.class);
+        var agent = mock(ClaudeSession.class);
+        when(environments.container(any())).thenReturn(container);
+        when(environments.agent(any(), any())).thenReturn(agent);
+        when(agent.send(anyString())).thenReturn("done");
+
+        assertEquals("done", takeover.send(RUN, "hello", List.of()));
+
+        // A person waiting in a browser gets the takeover budget, not a build
+        // turn's — an unanswered request is a hung dashboard, not a long job.
+        verify(agent).setTurnTimeout(Duration.ofMinutes(5));
+        verify(environments).rememberAgentSession(container, agent);
+    }
+
+    @Test
+    void theTurnLockIsReleasedWhenATurnFails() {
+        var container = mock(ContainerSession.class);
+        var agent = mock(ClaudeSession.class);
+        when(environments.container(any())).thenReturn(container);
+        when(environments.agent(any(), any())).thenReturn(agent);
+        when(agent.send(anyString())).thenThrow(new IllegalStateException("boom"));
+
+        assertThrows(IllegalStateException.class, () -> takeover.send(RUN, "hello", List.of()));
+
+        // A lock a failed turn kept would wedge the run for good.
+        assertFalse(locks.isBusy(RUN.id()));
+    }
+
+    @Test
+    void anUnsetTakeoverTimeoutFallsBackToTheBuiltInDefault() {
+        var container = mock(ContainerSession.class);
+        var agent = mock(ClaudeSession.class);
+        when(environments.container(any())).thenReturn(container);
+        when(environments.agent(any(), any())).thenReturn(agent);
+        when(agent.send(anyString())).thenReturn("done");
+
+        new RunTakeover(store, environments, locks, agentConfig(null)).send(RUN, "hello", List.of());
+
+        verify(agent).setTurnTimeout(Duration.ofMinutes(5));
+    }
+
+    private static ClaudeAgentConfig agentConfig(String takeoverTimeout) {
+        return new ClaudeAgentConfig("claude-opus-5", null, null, null, takeoverTimeout);
+    }
+}

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/service/claude/ClaudeTurnTimeoutTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/service/claude/ClaudeTurnTimeoutTest.java
@@ -1,0 +1,162 @@
+package dev.smithyai.orchestrator.service.claude;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.smithyai.orchestrator.config.AgentConfig.ClaudeAgentConfig;
+import dev.smithyai.orchestrator.config.BotConfig;
+import dev.smithyai.orchestrator.config.ClaudeConfig;
+import dev.smithyai.orchestrator.config.DockerConfig;
+import dev.smithyai.orchestrator.config.VcsProviderConfig;
+import dev.smithyai.orchestrator.service.docker.ContainerService;
+import dev.smithyai.orchestrator.service.docker.ContainerSession;
+import dev.smithyai.orchestrator.service.docker.dto.ExecResult;
+import dev.smithyai.orchestrator.testing.FakeDockerCli;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The wall-clock budget on an agent turn.
+ *
+ * <p>The deadline has to be enforced inside the container: the docker daemon does
+ * not stop an exec whose client went away, so a timeout applied only on this side
+ * leaves the CLI running, still working and still writing the transcript the next
+ * turn resumes. What is asserted is therefore the {@code timeout} prefix on the
+ * command the fake saw, not just the failure the caller gets.
+ */
+class ClaudeTurnTimeoutTest {
+
+    private FakeDockerCli docker;
+    private ContainerSession container;
+
+    @BeforeEach
+    void setUp() {
+        docker = new FakeDockerCli();
+        var containers = new ContainerService(dockerConfig(), claudeConfig(), vcsProviderConfig(), botConfig(), docker);
+        container = new ContainerSession("timeout-test", containers);
+    }
+
+    @AfterEach
+    void restoreDefaultTimeout() {
+        // The budget is static; put back the shipped value so no other test
+        // inherits what this one configured.
+        ClaudeSession.configureTurnTimeout(Duration.ofMinutes(60));
+    }
+
+    @Test
+    void theTurnIsBoundedInsideTheContainer() {
+        ClaudeSession.configureTurnTimeout(Duration.ofMinutes(45));
+
+        new ClaudeSession(container, List.of()).send("hi");
+
+        var args = claudeInvocation();
+        int i = args.indexOf("timeout");
+        assertTrue(i >= 0, "claude was not run under timeout: " + args);
+        assertEquals("--kill-after=10s", args.get(i + 1));
+        assertEquals("2700s", args.get(i + 2));
+        assertEquals("/usr/bin/claude", args.get(i + 3));
+    }
+
+    @Test
+    void aTurnThatOverrunsFailsWithItsBudgetAndTheKeyThatRaisesIt() {
+        ClaudeSession.configureTurnTimeout(Duration.ofMinutes(45));
+        // What GNU timeout returns for a command it had to stop.
+        docker.onExec("/usr/bin/claude", new ExecResult(124, "", ""));
+
+        var session = new ClaudeSession(container, List.of());
+        var thrown = assertThrows(ClaudeTimeoutException.class, () -> session.send("hi"));
+
+        assertEquals(Duration.ofMinutes(45), thrown.getBudget());
+        assertEquals("timeout-test", thrown.getContainerName());
+        assertTrue(thrown.getMessage().contains("45m"), thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("agent.claude.turnTimeout"), thrown.getMessage());
+    }
+
+    @Test
+    void aTurnThatFailsForAnotherReasonIsNotReportedAsATimeout() {
+        docker.onExec("/usr/bin/claude", new ExecResult(1, "", "Invalid API key"));
+
+        var session = new ClaudeSession(container, List.of());
+        var thrown = assertThrows(IllegalStateException.class, () -> session.send("hi"));
+
+        assertFalse(thrown instanceof ClaudeTimeoutException, thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("Invalid API key"), thrown.getMessage());
+    }
+
+    @Test
+    void anUnsetTurnTimeoutKeepsTheBuiltInDefault() {
+        assertTrue(agentConfig(null).resolvedTurnTimeout().isEmpty());
+        assertTrue(agentConfig("  ").resolvedTurnTimeout().isEmpty());
+    }
+
+    @Test
+    void aConfiguredTurnTimeoutAcceptsFriendlyAndIsoDurations() {
+        assertEquals(Duration.ofMinutes(45), agentConfig("45m").resolvedTurnTimeout().orElseThrow());
+        assertEquals(Duration.ofHours(2), agentConfig("2h").resolvedTurnTimeout().orElseThrow());
+        assertEquals(Duration.ofSeconds(900), agentConfig("900s").resolvedTurnTimeout().orElseThrow());
+        assertEquals(Duration.ofMinutes(45), agentConfig("PT45M").resolvedTurnTimeout().orElseThrow());
+    }
+
+    @Test
+    void aTurnTimeoutThatIsNotADurationFailsAtStartupNamingTheKey() {
+        var thrown = assertThrows(IllegalStateException.class, () -> agentConfig("soon").resolvedTurnTimeout());
+
+        assertTrue(thrown.getMessage().contains("agent.claude.turnTimeout"), thrown.getMessage());
+    }
+
+    @Test
+    void aNonPositiveTurnTimeoutIsRejectedRatherThanKillingEveryTurn() {
+        assertThrows(IllegalStateException.class, () -> agentConfig("0m").resolvedTurnTimeout());
+        assertThrows(IllegalStateException.class, () -> agentConfig("-5m").resolvedTurnTimeout());
+    }
+
+    // ── Plumbing ─────────────────────────────────────────────
+
+    private static ClaudeAgentConfig agentConfig(String turnTimeout) {
+        return new ClaudeAgentConfig("claude-opus-5", null, null, turnTimeout, null);
+    }
+
+    private List<String> claudeInvocation() {
+        return docker.invocations
+            .stream()
+            .filter(args -> args.contains("/usr/bin/claude"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no claude invocation reached the fake: " + docker.invocations));
+    }
+
+    private static DockerConfig dockerConfig() {
+        return new DockerConfig("docker", "smithy-net", "claude-task:test", null);
+    }
+
+    private static ClaudeConfig claudeConfig() {
+        return new ClaudeConfig("test-token", null, "claude-opus-5");
+    }
+
+    private static BotConfig botConfig() {
+        return new BotConfig(
+            new BotConfig.BotEntry("smithy", "smithy@localhost"),
+            new BotConfig.BotEntry("architect", "architect@localhost"),
+            new BotConfig.BotEntry("coordinator", "coordinator@localhost")
+        );
+    }
+
+    private static VcsProviderConfig vcsProviderConfig() {
+        return new VcsProviderConfig(
+            "forgejo",
+            null,
+            new VcsProviderConfig.ForgejoProviderConfig(
+                "http://forgejo.invalid",
+                "http://forgejo.invalid",
+                null,
+                "smithy-token",
+                "architect-token",
+                "coordinator-token"
+            ),
+            null,
+            null,
+            null
+        );
+    }
+}

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/ArchitectDefinitionTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/ArchitectDefinitionTest.java
@@ -177,7 +177,8 @@ class ArchitectDefinitionTest {
             store,
             environments,
             new RepositoryWorkflowLoader(vcs, new WorkflowDefinitionParser()),
-            debouncer
+            debouncer,
+            new RunLocks()
         );
     }
 

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/LiveEndToEndIT.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/LiveEndToEndIT.java
@@ -359,7 +359,8 @@ class LiveEndToEndIT {
             store,
             environments,
             new RepositoryWorkflowLoader(vcs, new WorkflowDefinitionParser()),
-            new EventDebouncer()
+            new EventDebouncer(),
+            new RunLocks()
         );
     }
 

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/SmithyDefinitionTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/testing/SmithyDefinitionTest.java
@@ -185,7 +185,8 @@ class SmithyDefinitionTest {
             store,
             environments,
             new RepositoryWorkflowLoader(vcs, new WorkflowDefinitionParser()),
-            new EventDebouncer()
+            new EventDebouncer(),
+            new RunLocks()
         );
 
         var outcome = engine.handle(issueAssigned()).stream().filter(RunEngine.Outcome::handled).findFirst();

--- a/orchestrator/frontend/src/api/client.ts
+++ b/orchestrator/frontend/src/api/client.ts
@@ -171,22 +171,46 @@ export function releaseTakeover(containerName: string, keepalive = false): Promi
   });
 }
 
+/**
+ * A turn is answered by the agent, so this is slow by nature — but not endless.
+ * Without a deadline a request that never comes back leaves the composer stuck
+ * with the draft still in it and no error, which reads as a prompt that was
+ * never sent. Kept above the server's takeover budget so the server's own
+ * message wins the race and says something useful.
+ */
+const TAKEOVER_MESSAGE_TIMEOUT_MS = 6 * 60 * 1000;
+
 export async function sendTakeoverMessage(
   containerName: string,
   text: string,
 ): Promise<string> {
-  const res = await fetch(
-    `/api/dashboard/takeover/${encodeURIComponent(containerName)}/message`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text }),
-    },
-  );
+  let res: Response;
+  try {
+    res = await fetch(
+      `/api/dashboard/takeover/${encodeURIComponent(containerName)}/message`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text }),
+        signal: AbortSignal.timeout(TAKEOVER_MESSAGE_TIMEOUT_MS),
+      },
+    );
+  } catch (e) {
+    if (e instanceof DOMException && e.name === "TimeoutError") {
+      throw new Error(
+        "The agent did not reply within 6 minutes. It may still be working — " +
+          "check the transcript before sending again.",
+      );
+    }
+    throw e;
+  }
   if (res.status === 401 || res.status === 403) {
     window.location.href = "/login";
     return "";
   }
+  // 409 is the session being mid-turn, 504 the turn running out of budget:
+  // both carry a sentence worth showing as-is.
+  if (res.status === 409 || res.status === 504) throw new Error(await res.text());
   if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
   return res.text();
 }


### PR DESCRIPTION
## The bug

A message sent from the dashboard after clicking "take control" never landed, and the request hung until the agent turn budget ran out:

```
java.lang.IllegalStateException: Claude process exited with code 124: Timed out after PT30M
```

`RunEngine.dispatch` serializes every dispatch under a per-run lock, for the reason its own javadoc gives:

> Two webhooks about the same run arriving together would otherwise run its steps concurrently — **two agent turns in one container**, two pull requests from one branch.

`RunTakeover.send` never took that lock — the map was private to `RunEngine` — so a human message fired a second `claude --resume` at a session that already had a process on it.

The HUMAN lease does not cover this either: it is checked at *dispatch entry*, so it holds back new events but not work already in flight. And taking control mid-turn is the designed use — `AgentRunAction` records the session id *before* the turn precisely so "the dashboard tails the transcript by session id while it does" — so the collision was routine rather than an edge case.

## Changes

**Concurrency (the actual fix)**

- `RunLocks` — the engine's private lock map extracted into a shared component. `RunEngine` still waits on it; `RunTakeover.send` tries for 5s and then reports `AgentBusyException` as a **409**, because someone typing in a browser wants to hear "the agent is busy" now rather than in half an hour.

**The timeout, which was neither configurable nor effective**

- The deadline ran only on the orchestrator's side. `destroyForcibly()` kills the local `docker exec`, but the daemon does not stop an exec whose client went away — so *every* timeout to date left an orphaned CLI still working and still writing the transcript the next turn resumes. The turn is now bounded inside the container with `timeout --kill-after=10s`, and the client-side wait became a backstop for a wedged daemon.
- `agent.claude.turnTimeout` makes the budget configurable (`45m`, `2h`, `900s`, `PT45M`), default raised **30m → 60m**: a build turn with `--max-turns 200` on a real repository does not reliably fit in thirty minutes.
- `agent.claude.takeoverTimeout` (default **5m**) gives a human-driven turn its own, much shorter budget.
- `ClaudeTimeoutException` replaces the bare `IllegalStateException`, naming the container, session, budget, and the key that raises it.

**The dashboard, which hid all of it**

- `sendTakeoverMessage` had no timeout and `handleSend` only cleared the draft on success, so a request that never returned left the composer full with no error — a prompt that looked as though it was never sent. It now aborts after 6 minutes and surfaces the 409/504 body.

## Test plan

- `RunTakeoverConcurrencyTest` (4) — refusal while a stand-in turn holds the lock, no second session opened on the container, lock released when a turn throws, takeover budget applied.
- `ClaudeTurnTimeoutTest` (7) — the in-container `timeout` prefix and its computed deadline, `ClaudeTimeoutException` on exit 124, non-timeout failures staying distinct, duration parsing incl. bad and non-positive values.
- Full `:backend:test` green; `tsc -b` clean; `spotlessApply` run.
- Not exercised end-to-end against a live orchestrator — see below.

## Reviewer notes

Two things worth a second opinion:

1. **One unverified assumption.** I could not test whether the CLI *blocks* on a session another process holds, versus erroring, without a live setup. The guard is correct either way — two processes on one session is a bug whatever the CLI does with it — but if anyone has orchestrator logs from an occurrence, the stderr would confirm the mechanism.
2. **`--allowedTools` is empty on every takeover message.** `DashboardController` passes `List.of()`, so `ClaudeSession` omits the flag entirely and the turn runs on default permissions rather than the workflow's tool list. Left alone as out of scope, but it likely means takeover turns cannot do what workflow turns can. Happy to fix here or in a follow-up.

Also note `orchestrator/libs/` holds `forgejo-client:14.0.3` in Maven layout, but `build.gradle.kts` only declares `mavenLocal()` and `mavenCentral()` — a clean checkout cannot resolve it. I built with an init script adding `libs` as a repository rather than change the build. Unrelated to this PR, but worth a look if it is not deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
