### PR TITLE
Give a takeover turn a tool list instead of none

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -26,6 +26,7 @@ agent:
     apiKey: {env: ANTHROPIC_API_KEY}
     turnTimeout: 60m          # budget for one agent turn; overrunning turns are killed
     takeoverTimeout: 5m       # budget for a turn a human drove from the dashboard
+    takeoverTools: [Read, Glob, Grep, Bash, Edit, Write, WebFetch]
 
 auth:
   admin:
@@ -113,6 +114,19 @@ The agent on run <id> is in the middle of a turn.
 ```
 
 rather than queued behind it. Wait for the turn to land, or stop the run.
+
+`agent.claude.takeoverTools` is the tool list a human-driven turn runs with,
+defaulting to `[Read, Glob, Grep, Bash, Edit, Write, WebFetch]`. It is separate
+from the stage's `tools:` on purpose: a definition scopes tools per step to
+constrain the agent while it works on its own — read-only while planning, write
+while building — and that does not map onto whatever a person asks for after
+taking control.
+
+Note that an **empty** tool list is not "no restrictions", it is "nothing
+allowed": the CLI is run without `--allowedTools`, and a headless turn on default
+permissions then refuses every tool call before executing it. The agent reports
+that it cannot read a file or push a branch, which reads as an agent refusing to
+cooperate rather than one that was handed no permissions.
 
 ## Secrets
 

--- a/examples/demo/config/orchestrator.yml
+++ b/examples/demo/config/orchestrator.yml
@@ -19,6 +19,7 @@ agent:
     apiKey: {env: ANTHROPIC_API_KEY}
     turnTimeout: 60m          # budget for one agent turn; overrunning turns are killed
     takeoverTimeout: 5m       # budget for a turn a human drove from the dashboard
+    takeoverTools: [Read, Glob, Grep, Bash, Edit, Write, WebFetch]
 
 auth:
   admin:

--- a/examples/full/config/orchestrator-jira-gitlab.yml
+++ b/examples/full/config/orchestrator-jira-gitlab.yml
@@ -15,6 +15,7 @@ agent:
     apiKey: {env: ANTHROPIC_API_KEY}
     turnTimeout: 60m          # budget for one agent turn; overrunning turns are killed
     takeoverTimeout: 5m       # budget for a turn a human drove from the dashboard
+    takeoverTools: [Read, Glob, Grep, Bash, Edit, Write, WebFetch]
 auth:
   admin:
     passwordHash: {env: ADMIN_PASSWORD_HASH}

--- a/examples/full/config/orchestrator.yml
+++ b/examples/full/config/orchestrator.yml
@@ -19,6 +19,7 @@ agent:
     apiKey: {env: ANTHROPIC_API_KEY}
     turnTimeout: 60m          # budget for one agent turn; overrunning turns are killed
     takeoverTimeout: 5m       # budget for a turn a human drove from the dashboard
+    takeoverTools: [Read, Glob, Grep, Bash, Edit, Write, WebFetch]
 
 auth:
   admin:

--- a/examples/github-local/orchestrator.yml
+++ b/examples/github-local/orchestrator.yml
@@ -14,6 +14,7 @@ agent:
     oauthToken: {env: CLAUDE_CODE_OAUTH_TOKEN}
     turnTimeout: 60m          # budget for one agent turn; overrunning turns are killed
     takeoverTimeout: 5m       # budget for a turn a human drove from the dashboard
+    takeoverTools: [Read, Glob, Grep, Bash, Edit, Write, WebFetch]
 auth:
   admin:
     passwordHash: {env: ADMIN_PASSWORD_HASH}

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/AgentConfig.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/config/AgentConfig.java
@@ -1,16 +1,41 @@
 package dev.smithyai.orchestrator.config;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 public record AgentConfig(ClaudeAgentConfig claude) {
+    private static final List<String> DEFAULT_TAKEOVER_TOOLS = List.of(
+        "Read",
+        "Glob",
+        "Grep",
+        "Bash",
+        "Edit",
+        "Write",
+        "WebFetch"
+    );
+
     public record ClaudeAgentConfig(
         String model,
         SecretRef oauthToken,
         SecretRef apiKey,
         String turnTimeout,
-        String takeoverTimeout
+        String takeoverTimeout,
+        List<String> takeoverTools
     ) {
+        /**
+         * Tools a human-driven turn may use.
+         *
+         * <p>Not the stage's list: a definition scopes tools per step to constrain
+         * the agent when it is working on its own — read-only while planning, write
+         * while building — and that does not map onto whatever a person decides to
+         * ask for after taking control. So this is its own setting, and it defaults
+         * to the full working set rather than to nothing.
+         */
+        public List<String> resolvedTakeoverTools() {
+            return takeoverTools == null || takeoverTools.isEmpty() ? DEFAULT_TAKEOVER_TOOLS : takeoverTools;
+        }
+
         /**
          * Wall-clock budget for one agent turn, or empty to keep the built-in
          * default. Accepts {@code 45m}, {@code 2h}, {@code 900s} or ISO-8601

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunTakeover.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunTakeover.java
@@ -44,16 +44,43 @@ public class RunTakeover {
      */
     private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(5);
 
+    /** Used only when there is no config bean at all — see agent.claude.takeoverTools. */
+    private static final List<String> DEFAULT_TOOLS = List.of(
+        "Read",
+        "Glob",
+        "Grep",
+        "Bash",
+        "Edit",
+        "Write",
+        "WebFetch"
+    );
+
     private final RunStore store;
     private final RunEnvironments environments;
     private final RunLocks locks;
     private final Duration turnTimeout;
+    private final List<String> defaultTools;
 
     public RunTakeover(RunStore store, RunEnvironments environments, RunLocks locks, ClaudeAgentConfig claude) {
         this.store = store;
         this.environments = environments;
         this.locks = locks;
         this.turnTimeout = claude == null ? DEFAULT_TIMEOUT : claude.resolvedTakeoverTimeout().orElse(DEFAULT_TIMEOUT);
+        this.defaultTools = claude == null ? DEFAULT_TOOLS : claude.resolvedTakeoverTools();
+    }
+
+    /**
+     * The tools a human-driven turn may use.
+     *
+     * <p>Never an empty list. {@code ClaudeSession} omits {@code --allowedTools}
+     * when it has nothing to put there, and a headless turn on default
+     * permissions then refuses every tool call before it runs — the agent cannot
+     * read a file, let alone push a branch. That looks like an agent that has
+     * stopped cooperating rather than one that was handed no permissions, so the
+     * empty case is filled in here instead of being passed on.
+     */
+    private List<String> toolsFor(List<String> requested) {
+        return requested == null || requested.isEmpty() ? defaultTools : requested;
     }
 
     public boolean isHeld(String runId) {
@@ -99,7 +126,7 @@ public class RunTakeover {
         return locks
             .tryInRun(run.id(), BUSY_WAIT, () -> {
                 var container = environments.container(run);
-                var agent = environments.agent(run, tools);
+                var agent = environments.agent(run, toolsFor(tools));
                 agent.setTurnTimeout(turnTimeout);
                 String reply = agent.send(text);
                 environments.rememberAgentSession(container, agent);

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/claude/ClaudeSession.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/service/claude/ClaudeSession.java
@@ -269,6 +269,16 @@ public class ClaudeSession {
         if (tools != null && !tools.isEmpty()) {
             command.add("--allowedTools");
             command.add(String.join(",", tools));
+        } else {
+            // Worth saying out loud: with no allowlist a headless turn on default
+            // permissions refuses every tool call before running it, so the agent
+            // reports that it cannot read a file or push a branch and looks broken
+            // rather than unprivileged.
+            log.warn(
+                "No tools allowed for the turn on {} (session={}); every tool call will be refused",
+                container.getContainerName(),
+                sessionId
+            );
         }
 
         for (String dir : addDirs) {

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/DashboardController.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/DashboardController.java
@@ -312,7 +312,9 @@ public class DashboardController {
             return ResponseEntity.status(409).body("No active takeover for this run");
         }
         try {
-            return ResponseEntity.ok(takeover.send(run.get(), request.text(), List.of()));
+            // null, not List.of(): an empty list is "no tools allowed", which
+            // leaves the agent unable to do anything the person asked for.
+            return ResponseEntity.ok(takeover.send(run.get(), request.text(), null));
         } catch (AgentBusyException e) {
             // 409 rather than 500: nothing is broken, the session is occupied.
             return ResponseEntity.status(409).body(e.getMessage());

--- a/orchestrator/backend/src/main/resources/orchestrator.yml
+++ b/orchestrator/backend/src/main/resources/orchestrator.yml
@@ -25,6 +25,10 @@ agent:
     # Budget for a turn a human drove from the dashboard, where someone is
     # waiting on the reply in a browser rather than on a build.
     takeoverTimeout: 5m
+    # Tools a human-driven turn may use. Not the stage's list: a definition
+    # scopes tools per step to constrain the agent working on its own, which
+    # does not map onto whatever a person asks for after taking control.
+    takeoverTools: [Read, Glob, Grep, Bash, Edit, Write, WebFetch]
 
 auth:
   admin:

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/engine/RunTakeoverConcurrencyTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/engine/RunTakeoverConcurrencyTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * A human message must not land on a session that is already mid-turn.
@@ -141,7 +142,43 @@ class RunTakeoverConcurrencyTest {
         verify(agent).setTurnTimeout(Duration.ofMinutes(5));
     }
 
+    @Test
+    void aTakeoverTurnGetsARealToolListRatherThanNone() {
+        var container = mock(ContainerSession.class);
+        var agent = mock(ClaudeSession.class);
+        when(environments.container(any())).thenReturn(container);
+        when(environments.agent(any(), any())).thenReturn(agent);
+        when(agent.send(anyString())).thenReturn("done");
+
+        // What the dashboard sends: it does not decide the tools.
+        takeover.send(RUN, "push the branch", null);
+
+        // An empty list makes ClaudeSession omit --allowedTools, and a headless
+        // turn on default permissions then refuses every tool call before running
+        // it — the agent cannot read a file, let alone push a branch.
+        var tools = ArgumentCaptor.forClass(List.class);
+        verify(environments).agent(any(), tools.capture());
+        assertFalse(tools.getValue().isEmpty(), "the turn was given no tools");
+        assertTrue(tools.getValue().contains("Bash"), "Bash missing: " + tools.getValue());
+        assertTrue(tools.getValue().contains("Read"), "Read missing: " + tools.getValue());
+    }
+
+    @Test
+    void anExplicitToolListStillWins() {
+        var container = mock(ContainerSession.class);
+        var agent = mock(ClaudeSession.class);
+        when(environments.container(any())).thenReturn(container);
+        when(environments.agent(any(), any())).thenReturn(agent);
+        when(agent.send(anyString())).thenReturn("done");
+
+        takeover.send(RUN, "read only please", List.of("Read"));
+
+        var tools = ArgumentCaptor.forClass(List.class);
+        verify(environments).agent(any(), tools.capture());
+        assertEquals(List.of("Read"), tools.getValue());
+    }
+
     private static ClaudeAgentConfig agentConfig(String takeoverTimeout) {
-        return new ClaudeAgentConfig("claude-opus-5", null, null, null, takeoverTimeout);
+        return new ClaudeAgentConfig("claude-opus-5", null, null, null, takeoverTimeout, null);
     }
 }

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/service/claude/ClaudeTurnTimeoutTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/service/claude/ClaudeTurnTimeoutTest.java
@@ -115,7 +115,7 @@ class ClaudeTurnTimeoutTest {
     // ── Plumbing ─────────────────────────────────────────────
 
     private static ClaudeAgentConfig agentConfig(String turnTimeout) {
-        return new ClaudeAgentConfig("claude-opus-5", null, null, turnTimeout, null);
+        return new ClaudeAgentConfig("claude-opus-5", null, null, turnTimeout, null, null);
     }
 
     private List<String> claudeInvocation() {


### PR DESCRIPTION
## The symptom

After taking control from the dashboard, the agent reports that it cannot do anything — and it is not being obstinate:

| Attempt | Result |
|---|---|
| `git push` ×4 (one with sandbox disabled) | This command requires approval |
| `git push` + `merge_request.create` options | This command requires approval |
| `git ls-remote` (read-only) | This command requires approval |
| Edit `.claude/settings.json` to add `Bash(git push:*)` | blocked |
| Read `/root/.claude/settings.json` | blocked |

Read-only calls refused too, which is the tell: this is not a scoping gap, the turn has **no** allowlist at all.

## Cause

`DashboardController` passed `List.of()` as the tools for a takeover turn. `ClaudeSession` omits `--allowedTools` entirely when the list is empty, and on `--permission-mode default` a headless turn auto-denies every tool call before executing it.

Workflow steps never hit this because each passes the definition's list — `{{ vars.buildTools }}`, `{{ vars.refineTools }}`, `tools: [Read, Glob, Grep, Bash]`. Only the takeover path passed nothing.

This is the same class of failure #42 fixed for the workflow path, and that PR's description states the mechanism exactly:

> In `claude -p` every permission prompt is auto-denied and no one can approve it, so any gap between what a turn is asked to do and what its allowlist permits surfaces as the agent pleading for write access.

#42 closed three such gaps for autonomous turns; it did not touch takeover, where the gap is total rather than partial.

## Changes

- **`RunTakeover` resolves the tool list**, from a new `agent.claude.takeoverTools` defaulting to `[Read, Glob, Grep, Bash, Edit, Write, WebFetch]`. An explicit list passed by a caller still wins.
- **`DashboardController` passes `null`, not `List.of()`** — it should not be the thing deciding what a turn may do.
- **`ClaudeSession` warns when a turn is built with no tools.** The empty case produces a completely inert agent, so it should say so in the log rather than look like a refusal to the person reading the transcript.

### Why its own setting rather than the stage's list

A definition scopes tools per step to constrain the agent while it works **on its own** — read-only while planning, write while building. That intent does not carry over to whatever a person decides to ask for after taking control, and picking a stage's list would also mean guessing which var a definition happened to use (`tools`, `refineTools`, `buildTools` all appear in the shipped definitions). So it is explicit and configurable.

Worth a reviewer's opinion: the default is unscoped `Edit`/`Write`, where #42 used forms scoped to the plan directory. For a human-directed turn I think unscoped is right — the person is the one deciding — but if you would rather takeover stayed narrower, this is the line to change.

## Test plan

- `RunTakeoverConcurrencyTest` gains 2 tests: a turn is never handed an empty list (captures the argument reaching `RunEnvironments.agent`, asserts `Read`/`Bash` present), and an explicit list still wins.
- Full `:backend:test` green; `spotlessApply` run.
- Not verified end-to-end against a live orchestrator — worth one manual takeover push before trusting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
