### PR TITLE
Dashboard: cascade cancel with children, and show each run's story key

### DIFF
--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/store/RunStore.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/store/RunStore.java
@@ -199,6 +199,19 @@ public class RunStore {
         db.sql("DELETE FROM run_correlations WHERE kind = ? AND ref = ?").params(kind.value(), ref).update();
     }
 
+    /**
+     * The routing key that owns this run, if any — how a dashboard reader tells
+     * which story or issue a run belongs to, since the run itself only knows
+     * its workflow.
+     */
+    public Optional<String> findKeyRef(String runId) {
+        return db
+            .sql("SELECT ref FROM run_correlations WHERE kind = ? AND run_id = ? LIMIT 1")
+            .params(CorrelationKind.KEY.value(), runId)
+            .query(String.class)
+            .optional();
+    }
+
     // ── Events ───────────────────────────────────────────────
 
     /**

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/DashboardController.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/DashboardController.java
@@ -79,7 +79,7 @@ public class DashboardController {
             .map(run -> {
                 var containers = runStore.findEnvironmentNames(run.id(), RunRecorder.CONTAINER);
                 boolean live = containers.stream().anyMatch(running::contains);
-                return RunDto.from(run, containers, live);
+                return RunDto.from(run, containers, live, keyOf(run.id()));
             })
             .toList();
     }
@@ -91,9 +91,20 @@ public class DashboardController {
             .map(run -> {
                 var containers = runStore.findEnvironmentNames(run.id(), RunRecorder.CONTAINER);
                 var running = new HashSet<>(containerService.listManagedContainers());
-                return ResponseEntity.ok(RunDto.from(run, containers, containers.stream().anyMatch(running::contains)));
+                return ResponseEntity.ok(
+                    RunDto.from(run, containers, containers.stream().anyMatch(running::contains), keyOf(run.id()))
+                );
             })
             .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * The routing key a run answers to, without the workflow prefix — the
+     * workflow is already its own column, and "story:acme/product#PROD-1" is
+     * the part a reader needs to tell two runs of the same workflow apart.
+     */
+    private String keyOf(String runId) {
+        return runStore.findKeyRef(runId).map(ref -> ref.substring(ref.indexOf('|') + 1)).orElse(null);
     }
 
     /** A run's timeline, oldest first. */
@@ -114,7 +125,7 @@ public class DashboardController {
                 .stream()
                 .map(child -> {
                     var containers = runStore.findEnvironmentNames(child.id(), RunRecorder.CONTAINER);
-                    return RunDto.from(child, containers, containers.stream().anyMatch(running::contains));
+                    return RunDto.from(child, containers, containers.stream().anyMatch(running::contains), keyOf(child.id()));
                 })
                 .toList()
         );
@@ -172,27 +183,39 @@ public class DashboardController {
     }
 
     /**
-     * Stop a run.
+     * Stop a run, and everything it spawned.
      *
      * <p>Cancelling is a decision about the run, not about the container: the
      * container goes, the history stays, and the dashboard keeps showing what
-     * happened and where it stopped.
+     * happened and where it stopped. Children go with it — a coordinator
+     * cancelled from here must not leave its child runs working for a parent
+     * that no longer reacts, and cleaning them up one by one through the API
+     * is exactly the chore this endpoint exists to remove.
      */
     @DeleteMapping("/dashboard/runs/{runId}")
     public ResponseEntity<RunDto> cancelRun(@PathVariable String runId) {
         var run = runStore.find(runId);
         if (run.isEmpty()) return ResponseEntity.notFound().build();
-        if (run.get().isTerminal()) return ResponseEntity.ok(RunDto.from(run.get(), List.of(), false));
+        int cancelled = cancelWithChildren(run.get());
+        log.info("Run {} cancelled from the dashboard ({} run(s) including children)", runId, cancelled);
+        return ResponseEntity.ok(RunDto.from(runStore.find(runId).orElseThrow(), List.of(), false, keyOf(runId)));
+    }
 
-        try {
-            environments.destroyContainer(run.get());
-        } catch (RuntimeException e) {
-            log.warn("Could not release the container while cancelling run {}", runId, e);
+    /** Depth-first, children before their parent, already-terminal runs left alone. */
+    private int cancelWithChildren(dev.smithyai.orchestrator.runtime.store.Run run) {
+        int cancelled = 0;
+        for (var child : runStore.findChildren(run.id())) {
+            cancelled += cancelWithChildren(child);
         }
-        runStore.appendEvent(runId, "run.cancelled", Map.of("via", "dashboard"));
-        runStore.updateStatus(runId, RunStatus.CANCELLED);
-        log.info("Run {} cancelled from the dashboard", runId);
-        return ResponseEntity.ok(RunDto.from(runStore.find(runId).orElseThrow(), List.of(), false));
+        if (run.isTerminal()) return cancelled;
+        try {
+            environments.destroyContainer(run);
+        } catch (RuntimeException e) {
+            log.warn("Could not release the container while cancelling run {}", run.id(), e);
+        }
+        runStore.appendEvent(run.id(), "run.cancelled", Map.of("via", "dashboard"));
+        runStore.updateStatus(run.id(), RunStatus.CANCELLED);
+        return cancelled + 1;
     }
 
     /**

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/dto/RunDto.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/dto/RunDto.java
@@ -19,9 +19,13 @@ public record RunDto(
     boolean live,
     Instant createdAt,
     Instant updatedAt,
-    Instant terminalAt
+    Instant terminalAt,
+    // The routing key the run was created under, e.g. "story:acme/product#PROD-1"
+    // — how a reader tells two runs of the same workflow apart. Null for runs
+    // that were spawned rather than routed.
+    String key
 ) {
-    public static RunDto from(Run run, List<String> containers, boolean live) {
+    public static RunDto from(Run run, List<String> containers, boolean live, String key) {
         return new RunDto(
             run.id(),
             run.workflowName(),
@@ -32,7 +36,8 @@ public record RunDto(
             live,
             run.createdAt(),
             run.updatedAt(),
-            run.terminalAt()
+            run.terminalAt(),
+            key
         );
     }
 }

--- a/orchestrator/frontend/src/api/client.ts
+++ b/orchestrator/frontend/src/api/client.ts
@@ -34,6 +34,8 @@ export interface Run {
   createdAt: string;
   updatedAt: string;
   terminalAt: string | null;
+  /** Routing key without the workflow prefix, e.g. "story:acme/product#PROD-1". */
+  key: string | null;
 }
 
 export async function fetchRuns(limit = 100): Promise<Run[]> {

--- a/orchestrator/frontend/src/pages/RunsTable.tsx
+++ b/orchestrator/frontend/src/pages/RunsTable.tsx
@@ -150,6 +150,11 @@ function RunRow({
               </Badge>
             )}
           </Group>
+          {run.key && (
+            <Text size="xs" ff="monospace" c="dimmed">
+              {run.key}
+            </Text>
+          )}
         </Table.Td>
         <Table.Td>{run.state}</Table.Td>
         <Table.Td>
@@ -192,7 +197,18 @@ function RunRow({
                 variant="subtle"
                 color="red"
                 loading={cancel.isPending}
-                onClick={() => cancel.mutate()}
+                title="Cancels this run and every child run it spawned"
+                onClick={() => {
+                  if (
+                    window.confirm(
+                      `Cancel this ${run.workflowName} run${run.key ? ` (${run.key})` : ""} and all of its child runs?\n\n` +
+                        "Their containers are removed; the history stays. " +
+                        "Re-assigning the issue afterwards restarts it from scratch.",
+                    )
+                  ) {
+                    cancel.mutate();
+                  }
+                }}
               >
                 Cancel
               </Button>


### PR DESCRIPTION
## Why

Recovering a stuck coordinator today means: finding the right run among many identical-looking rows (the list shows only the workflow name), cancelling it via curl because children aren't covered, then hunting down each child run by id. Lived through this on a real stuck story — twice, because a twin run turned out to own the routing key.

## What changed

- **`DELETE /api/dashboard/runs/{id}` cascades**: children are cancelled depth-first before their parent; already-terminal runs are left alone. The response and endpoint shape are unchanged.
- **Each `RunDto` now carries `key`** — the routing key the run was created under, without the workflow prefix (e.g. `story:acme/product#PROD-1`), read back from the run's KEY correlation. The runs table shows it under the workflow name, so two runs of the same coordinator are finally distinguishable.
- **The Cancel button asks first**, and its confirm text explains the cascade and that re-assigning the issue afterwards restarts the run from scratch (a cancelled run is reopened by the next `issue.assigned` — that part already existed in the engine).

## Tests

Full `:backend:test` and the frontend TypeScript build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)