### PR TITLE
Survive duplicate webhook deliveries: drop repeats, create runs atomically

### DIFF
--- a/docs/src/workflows/reference.md
+++ b/docs/src/workflows/reference.md
@@ -215,6 +215,7 @@ on.
 | `issue.comment` | `owner`, `repo`, `issue`, `body` | none | `commentId` |
 | `issue.read` | `owner`, `repo`, `issue` | none | `issueRef`, `title`, `body`, `state`, `assignees`, `labels`, `baseBranch` |
 | `issue.link` | `owner`, `repo`, `issue` | none | `url` |
+| `issue.comments` | `owner`, `repo`, `issue` | none | `comments[]` (`author`, `body`, `createdAt`), `count` |
 | `attachments.fetch` | `owner`, `repo`, `issue` | none | `paths`, `count` |
 
 ### Pull requests

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/actions/IssueActions.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/actions/IssueActions.java
@@ -98,6 +98,45 @@ public class IssueActions {
         };
     }
 
+    /**
+     * Read an issue's comment thread.
+     *
+     * <p>Decisions live in the discussion, not the description: "skip that part
+     * for now", "these two must ship together". A planning turn that reads only
+     * the description re-litigates every one of them after a reset — this is
+     * how a workflow hands the agent the conversation so far.
+     */
+    @Bean
+    public WorkflowAction issueCommentsAction(IssueTrackers trackers) {
+        return new WorkflowAction() {
+            @Override
+            public String type() {
+                return "issue.comments";
+            }
+
+            @Override
+            public boolean idempotent() {
+                return true;
+            }
+
+            @Override
+            public Map<String, Object> execute(ActionContext context, Map<String, Object> input) {
+                var comments = Trackers.pick(this, context, input, trackers)
+                    .getIssueComments(required(input, "owner"), required(input, "repo"), required(input, "issue"))
+                    .stream()
+                    .map(comment -> {
+                        var entry = new LinkedHashMap<String, Object>();
+                        entry.put("author", comment.userLogin());
+                        entry.put("body", comment.body());
+                        entry.put("createdAt", String.valueOf(comment.createdAt()));
+                        return entry;
+                    })
+                    .toList();
+                return Map.of("comments", comments, "count", comments.size());
+            }
+        };
+    }
+
     @Bean
     public WorkflowAction issueLabelAction(IssueTrackers trackers) {
         return new WorkflowAction() {

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunEngine.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunEngine.java
@@ -139,7 +139,27 @@ public class RunEngine implements SignalDelivery {
         ).or(() -> owner.filter(run -> run.workflowName().equals(name)));
 
         return switch (decision.action()) {
-            case create -> create(definition, key, existing, owner, event);
+            // Resolution and creation under a per-key lock: two identical
+            // deliveries arriving together must not each conclude "no run yet"
+            // and race two runs — and two same-named containers — into
+            // existence. Only the bookkeeping is locked; the dispatch below
+            // runs outside it, serialized per run by the run's own lock.
+            case create -> {
+                Run target = locks.inRun("create|" + (key == null ? name : key), () -> {
+                    var fresh = key == null
+                        ? Optional.<Run>empty()
+                        : store.findByCorrelation(CorrelationKind.KEY, key);
+                    var own = ownerOf(event);
+                    return resolveForCreate(
+                        definition,
+                        key,
+                        fresh.or(() -> own.filter(run -> run.workflowName().equals(name))),
+                        own,
+                        event
+                    );
+                });
+                yield target == null ? Outcome.ignored(name) : dispatch(definition, target, event);
+            }
             case dispatch -> existing
                 .map(run -> dispatch(definition, run, event))
                 .orElseGet(() -> {
@@ -159,20 +179,20 @@ public class RunEngine implements SignalDelivery {
     }
 
     /**
-     * Start a run for this event, adopt the one that already owns it, or stand
-     * aside.
+     * The run this event should be dispatched to: the one that already owns
+     * the key, a fresh one, or none at all (stand aside).
      *
-     * <p>The middle case is what makes a coordinator work. It creates a child
+     * <p>The adoption case is what makes a coordinator work. It creates a child
      * issue, spawns the run that will do the work, and correlates the two; the
      * assignment webhook then arrives and must find that run rather than open a
      * second, unrelated one beside it.
      *
-     * <p>The last case is what stops a coordinator fanning out from its own
-     * children. It listens for assigned issues, and every child it creates is an
-     * assigned issue — so without this a configured coordinator would plan a
-     * feature for each task of the feature it just planned.
+     * <p>The stand-aside case is what stops a coordinator fanning out from its
+     * own children. It listens for assigned issues, and every child it creates
+     * is an assigned issue — so without this a configured coordinator would
+     * plan a feature for each task of the feature it just planned.
      */
-    private Outcome create(
+    private Run resolveForCreate(
         WorkflowDefinition definition,
         String key,
         Optional<Run> existing,
@@ -193,7 +213,7 @@ public class RunEngine implements SignalDelivery {
                     owned.workflowName(),
                     definition.metadata().name()
                 );
-                return dispatch(definition, start(definition, key, event), event);
+                return start(definition, key, event);
             }
             log.debug(
                 "{} stands aside: this work already belongs to run {} ({})",
@@ -201,12 +221,11 @@ public class RunEngine implements SignalDelivery {
                 owner.get().id(),
                 owner.get().workflowName()
             );
-            return Outcome.ignored(definition.metadata().name());
+            return null;
         }
-        var run = existing
+        return existing
             .map(found -> found.isTerminal() ? reopen(definition, found) : found)
             .orElseGet(() -> start(definition, key, event));
-        return dispatch(definition, run, event);
     }
 
     /** The run that already owns the thing this event is about, whatever workflow it belongs to. */

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/WebhookController.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/WebhookController.java
@@ -31,17 +31,20 @@ public class WebhookController {
     private final ConnectorEventMappers eventMappers;
     private final WorkflowService workflowService;
     private final ObjectMapper mapper;
+    private final WebhookDeduplicator deduplicator;
 
     public WebhookController(
         ConnectorRegistry connectors,
         ConnectorEventMappers eventMappers,
         WorkflowService workflowService,
-        ObjectMapper mapper
+        ObjectMapper mapper,
+        WebhookDeduplicator deduplicator
     ) {
         this.connectors = connectors;
         this.eventMappers = eventMappers;
         this.workflowService = workflowService;
         this.mapper = mapper;
+        this.deduplicator = deduplicator;
     }
 
     @PostMapping("/webhooks/{connectorId}")
@@ -65,6 +68,13 @@ public class WebhookController {
         }
         if (!"jira".equals(provider) && (eventType == null || eventType.isBlank())) {
             return ResponseEntity.badRequest().body("Missing event type");
+        }
+
+        // After the signature check, so an attacker cannot pre-poison the seen
+        // set; before the mapping, so a duplicate costs nothing downstream.
+        if (!deduplicator.firstDelivery(deliveryKeys(provider, connectorId, body, headers))) {
+            log.info("Dropping duplicate {} webhook delivery for connector {}", provider, connectorId);
+            return ResponseEntity.ok("Duplicate delivery ignored");
         }
 
         try {
@@ -119,6 +129,42 @@ public class WebhookController {
     private static String header(HttpHeaders headers, String name) {
         String value = headers.getFirst(name);
         return value == null ? "" : value;
+    }
+
+    /**
+     * Everything that identifies this delivery: the provider's delivery id
+     * (absent on some providers and on old versions) and a digest of the body.
+     * Both are scoped to the connector — two connectors may legitimately
+     * receive the same payload.
+     */
+    private static java.util.List<String> deliveryKeys(
+        String provider,
+        String connectorId,
+        byte[] body,
+        HttpHeaders headers
+    ) {
+        String deliveryId = switch (provider) {
+            case "jira" -> header(headers, "X-Atlassian-Webhook-Identifier");
+            case "github" -> header(headers, "X-GitHub-Delivery");
+            case "gitlab" -> header(headers, "X-Gitlab-Event-UUID");
+            case "forgejo" -> {
+                String forgejo = header(headers, "X-Forgejo-Delivery");
+                yield forgejo.isBlank() ? header(headers, "X-Gitea-Delivery") : forgejo;
+            }
+            default -> "";
+        };
+        return java.util.List.of(
+            deliveryId.isBlank() ? "" : connectorId + "|id|" + deliveryId,
+            connectorId + "|body|" + sha256(body)
+        );
+    }
+
+    private static String sha256(byte[] body) {
+        try {
+            return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(body));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
     }
 
     private static boolean constantTimeEquals(String expected, String actual) {

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/WebhookDeduplicator.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/web/WebhookDeduplicator.java
@@ -1,0 +1,50 @@
+package dev.smithyai.orchestrator.web;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+/**
+ * Drops webhook deliveries the orchestrator has already seen.
+ *
+ * <p>Providers redeliver: a timeout on our side triggers a retry, and a
+ * misconfigured tracker with the same webhook registered twice sends every
+ * event twice. Observed live: one "approved" answered twice, one approval
+ * delivered five times in four milliseconds, and two simultaneous assignment
+ * deliveries racing two runs into existence — the second recreating the
+ * first's same-named container and killing the agent turn inside it (exit
+ * 137). Deduplication here is the first line of defence; the per-key run
+ * creation lock in the engine is the second.
+ *
+ * <p>A delivery is identified by every key the caller can offer — the
+ * provider's delivery id and a hash of the body — and is a duplicate if any
+ * of them was seen inside the window. Two keys, because neither is complete
+ * alone: a provider retry reuses the body but may or may not reuse the id,
+ * and two registrations of the same webhook send the same body under two ids.
+ */
+@Component
+public class WebhookDeduplicator {
+
+    private static final Duration WINDOW = Duration.ofMinutes(5);
+
+    private final Map<String, Instant> seen = new ConcurrentHashMap<>();
+
+    /**
+     * @return true when this delivery is new; false when any of its keys was
+     *         already seen inside the window (and the caller should drop it)
+     */
+    public boolean firstDelivery(List<String> keys) {
+        Instant now = Instant.now();
+        seen.values().removeIf(at -> at.plus(WINDOW).isBefore(now));
+
+        boolean fresh = true;
+        for (String key : keys) {
+            if (key == null || key.isBlank()) continue;
+            if (seen.putIfAbsent(key, now) != null) fresh = false;
+        }
+        return fresh;
+    }
+}

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/RunEngineTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/RunEngineTest.java
@@ -187,6 +187,35 @@ class RunEngineTest {
         );
     }
 
+    /**
+     * Observed live: Jira delivering the same assignment twice, two threads
+     * each concluding "no run yet", and two runs — with two same-named
+     * containers, the second recreating the first's and killing the agent turn
+     * inside it. Creation is resolved under a per-key lock now, so however many
+     * identical deliveries race, exactly one run exists afterwards.
+     */
+    @Test
+    void simultaneousIdenticalDeliveriesCreateExactlyOneRun() throws Exception {
+        int deliveries = 8;
+        var barrier = new java.util.concurrent.CyclicBarrier(deliveries);
+        var threads = new java.util.ArrayList<Thread>();
+        for (int i = 0; i < deliveries; i++) {
+            threads.add(
+                Thread.ofVirtual().start(() -> {
+                    try {
+                        barrier.await();
+                    } catch (Exception e) {
+                        throw new IllegalStateException(e);
+                    }
+                    engine.handle(assigned());
+                })
+            );
+        }
+        for (var thread : threads) thread.join();
+
+        assertEquals(1, store.findRecent(50).size(), "one run, however many times the webhook was delivered");
+    }
+
     @Test
     void anEventStartsARunAndItsStepsExecute() {
         var outcomes = engine.handle(assigned());

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/web/WebhookDeduplicatorTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/web/WebhookDeduplicatorTest.java
@@ -1,0 +1,41 @@
+package dev.smithyai.orchestrator.web;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class WebhookDeduplicatorTest {
+
+    private final WebhookDeduplicator deduplicator = new WebhookDeduplicator();
+
+    @Test
+    void theFirstDeliveryPassesAndItsRepeatDoesNot() {
+        assertTrue(deduplicator.firstDelivery(List.of("jira|id|abc", "jira|body|1111")));
+        assertFalse(deduplicator.firstDelivery(List.of("jira|id|abc", "jira|body|1111")));
+    }
+
+    @Test
+    void aMatchOnAnyKeyIsEnoughToDrop() {
+        // Two registrations of the same webhook: different delivery ids, same body.
+        assertTrue(deduplicator.firstDelivery(List.of("jira|id|first", "jira|body|same")));
+        assertFalse(deduplicator.firstDelivery(List.of("jira|id|second", "jira|body|same")));
+
+        // A provider retry: same delivery id, and the body hash was seen too.
+        assertFalse(deduplicator.firstDelivery(List.of("jira|id|first", "jira|body|other")));
+    }
+
+    @Test
+    void distinctDeliveriesBothPass() {
+        assertTrue(deduplicator.firstDelivery(List.of("jira|id|a", "jira|body|1")));
+        assertTrue(deduplicator.firstDelivery(List.of("jira|id|b", "jira|body|2")));
+    }
+
+    @Test
+    void blankKeysNeverCollide() {
+        // A provider with no delivery-id header contributes an empty key; two
+        // different bodies must not be treated as duplicates because of it.
+        assertTrue(deduplicator.firstDelivery(List.of("", "gitlab|body|1")));
+        assertTrue(deduplicator.firstDelivery(List.of("", "gitlab|body|2")));
+    }
+}


### PR DESCRIPTION
## Why

One evening of production evidence: a single "approved" comment answered twice; one `plan_approved` delivered **five times in four milliseconds**; and two simultaneous `issue.assigned` deliveries racing **two runs** into existence for the same story — the second run recreating the first's same-named container and SIGKILLing the agent turn inside it (`Claude process exited with code 137`), leaving the story silent and an orphan run stuck forever.

## What changed — two layers of defence

**1. Webhook dedup (`WebhookDeduplicator`)**: the controller drops deliveries already seen inside a 5-minute window. A delivery is identified by *both* the provider's delivery id (`X-Atlassian-Webhook-Identifier`, `X-GitHub-Delivery`, `X-Gitlab-Event-UUID`, `X-Forgejo-Delivery`) *and* a SHA-256 of the body, scoped per connector — matching either is enough. Two keys because neither is complete alone: a provider retry reuses the body but not always the id, and the same webhook registered twice sends one body under two ids. The check runs **after** signature verification (no poisoning by unauthenticated posts) and before mapping. Dropping a retry of a delivery we did process (but answered too slowly) is correct: the work is already running.

**2. Atomic run creation (`RunEngine`)**: the create path resolves find-or-adopt-or-start under a per-key lock (reusing `RunLocks`), so however many identical deliveries slip through, exactly one run ever owns a routing key. Only the bookkeeping is inside the lock — the dispatch still runs outside, serialized per run by the existing run lock. `create()` became `resolveForCreate()` returning the target run (or null for stand-aside), with the transfer/adopt/reopen semantics unchanged.

**3. Bonus: `issue.comments` action** — returns an issue's comment thread (`author`, `body`, `createdAt`). Decisions live in the discussion, not the description ("skip that part for now"); a planning workflow can now feed the conversation to the agent, so a re-planned run stops re-litigating settled questions. Documented in the actions reference.

## Tests

- `RunEngineTest.simultaneousIdenticalDeliveriesCreateExactlyOneRun` — 8 threads, one event, one run.
- `WebhookDeduplicatorTest` — repeat dropped, any-key match drops, distinct deliveries pass, blank keys never collide.
- Full `:backend:test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)