### PR TITLE
A reopened run leaves its previous life's children behind

### DIFF
--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunEngine.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/engine/RunEngine.java
@@ -374,10 +374,26 @@ public class RunEngine implements SignalDelivery {
         String initial = definition.state().getInitial();
         store.clearSteps(stopped.id());
         store.clearPendingWaits(stopped.id());
+        // The children belong to the life that was cancelled, not to this one.
+        // Observed live: a story reset over several rounds dragged seventeen
+        // dead children along, and every run.await/run.wave counted them —
+        // "all children finished" was true the moment the first new child
+        // reported in. A reopened run starts from the beginning, childless.
+        int orphaned = store.orphanChildren(stopped.id());
         store.updateState(stopped.id(), initial);
         store.updateStatus(stopped.id(), RunStatus.RUNNING);
-        store.appendEvent(stopped.id(), "run.reopened", Map.of("was", stopped.status().value(), "state", initial));
-        log.info("Run {} ({}) reopened from {}", stopped.id(), stopped.workflowName(), stopped.status().value());
+        store.appendEvent(
+            stopped.id(),
+            "run.reopened",
+            Map.of("was", stopped.status().value(), "state", initial, "orphanedChildren", orphaned)
+        );
+        log.info(
+            "Run {} ({}) reopened from {} ({} children from its previous life detached)",
+            stopped.id(),
+            stopped.workflowName(),
+            stopped.status().value(),
+            orphaned
+        );
         return store.find(stopped.id()).orElse(stopped);
     }
 

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/store/RunStore.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/runtime/store/RunStore.java
@@ -110,6 +110,17 @@ public class RunStore {
             .list();
     }
 
+    /**
+     * Detach a run's children — they stay in the store with their history, but
+     * no longer count as anyone's. Used when a run is reopened: the children of
+     * its previous life are done or dead, and a wave or await in the new life
+     * must not count them.
+     */
+    @org.springframework.transaction.annotation.Transactional
+    public int orphanChildren(String parentRunId) {
+        return db.sql("UPDATE runs SET parent_run_id = NULL WHERE parent_run_id = ?").param(parentRunId).update();
+    }
+
     /** Most recent runs first — what the dashboard lists. */
     public List<Run> findRecent(int limit) {
         return db.sql("SELECT * FROM runs ORDER BY created_at DESC LIMIT ?").param(limit).query(RUN_MAPPER).list();

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/RunEngineTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/runtime/RunEngineTest.java
@@ -336,6 +336,27 @@ class RunEngineTest {
     }
 
     @Test
+    void aReopenedRunLeavesThePreviousLifesChildrenBehind() {
+        var started = engine.handle(assigned()).getFirst();
+        var child = store.create("smithy-development", "1", "new", started.runId());
+        store.updateStatus(child.id(), RunStatus.COMPLETED);
+        assertEquals(1, store.findChildren(started.runId()).size());
+
+        engine.handle(unassigned());
+        engine.handle(assigned());
+
+        // Observed live: a story reset over several rounds dragged seventeen
+        // dead children along, and run.await counted them — "all children
+        // finished" was true the moment the first new child reported in.
+        assertTrue(
+            store.findChildren(started.runId()).isEmpty(),
+            "children of the cancelled life must not count in the new one"
+        );
+        var orphan = store.find(child.id()).orElseThrow();
+        assertNull(orphan.parentRunId(), "the old child keeps its history, just not its parent");
+    }
+
+    @Test
     void workTakenOffTheAgentAndHandedBackPicksUpWhereItStarted() {
         var started = engine.handle(assigned()).getFirst();
         engine.handle(unassigned());


### PR DESCRIPTION
## Why

Reopening a cancelled run keeps its children. A story that gets reset a few times therefore drags every dead child of every previous round along — observed live with **seventeen** — and `run.await`/`run.wave` count all of them: "all children finished" is true the moment the first child of the *new* round reports in. The coordinator declared a two-repository feature complete twelve seconds after the first repository delivered, on every retry, no matter how the workflow counted (`count: all` and `count: <n>` both break — the graveyard satisfies either).

## What changed

`reopen()` detaches the previous life's children (`RunStore.orphanChildren`: `parent_run_id = NULL`). They keep their runs and their history — they just stop being counted by a life they never belonged to. The reopened-run event records how many were detached.

## Test

`RunEngineTest.aReopenedRunLeavesThePreviousLifesChildrenBehind` — child of the first life is completed; after unassign + reassign the parent has no children and the orphan keeps its history. Full `:backend:test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)