### PR TITLE
Explain ignored human gestures instead of dropping them at DEBUG

### DIFF
--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/IgnoredEventExplainer.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/IgnoredEventExplainer.java
@@ -1,0 +1,116 @@
+package dev.smithyai.orchestrator.workflow;
+
+import dev.smithyai.orchestrator.model.events.WorkflowEvent;
+import dev.smithyai.orchestrator.runtime.engine.RunEngine;
+import dev.smithyai.orchestrator.runtime.store.CorrelationKind;
+import dev.smithyai.orchestrator.runtime.store.Run;
+import dev.smithyai.orchestrator.runtime.store.RunRecorder;
+import dev.smithyai.orchestrator.runtime.store.RunStatus;
+import dev.smithyai.orchestrator.runtime.store.RunStore;
+import dev.smithyai.orchestrator.service.vcs.IssueTrackers;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Says why nothing happened.
+ *
+ * <p>A person assigning an issue, approving a plan or asking a question in a
+ * comment is talking to the bot. When no workflow reacts — the run completed,
+ * the current stage has no ear for that event, no workflow claims the project —
+ * the engine used to drop the event at DEBUG level, and the person got
+ * silence. Every one of those silences was eventually investigated by hand,
+ * at a cost of hours; each investigation ended in a one-line explanation that
+ * this class now posts up front.
+ *
+ * <p>Only human gestures on issues are answered: assignment, plan approval,
+ * comment. Machine traffic (pushes, CI, PR events) goes unhandled all the time
+ * and legitimately so. A comment on an issue no run has ever owned is a human
+ * conversation and none of the bot's business — that one stays silent.
+ */
+@Slf4j
+@Component
+public class IgnoredEventExplainer {
+
+    private final RunStore store;
+    private final IssueTrackers trackers;
+
+    public IgnoredEventExplainer(RunStore store, IssueTrackers trackers) {
+        this.store = store;
+        this.trackers = trackers;
+    }
+
+    public void explainIfIgnored(WorkflowEvent event, List<RunEngine.Outcome> outcomes) {
+        if (outcomes.stream().anyMatch(RunEngine.Outcome::handled)) return;
+        if (!(event instanceof WorkflowEvent.IssueScoped scoped)) return;
+
+        String gesture = switch (event) {
+            case WorkflowEvent.IssueAssigned ignored -> "assignment";
+            case WorkflowEvent.PlanApproved ignored -> "plan approval";
+            case WorkflowEvent.IssueComment ignored -> "comment";
+            default -> null;
+        };
+        if (gesture == null) return;
+
+        var ctx = scoped.ctx();
+        var owner = store.findByCorrelation(
+            CorrelationKind.ISSUE,
+            RunRecorder.issueRef(ctx.info().owner(), ctx.info().repo(), ctx.issueRef())
+        );
+
+        String reason = reasonFor(gesture, owner);
+        if (reason == null) return;
+
+        try {
+            trackers
+                .forConnector("", event.source())
+                .createIssueComment(ctx.info().owner(), ctx.info().repo(), ctx.issueRef(), reason);
+            log.info("Explained an ignored {} on {}#{}", gesture, ctx.info().fullName(), ctx.issueRef());
+        } catch (RuntimeException e) {
+            // The explanation is a courtesy; failing to deliver it must not
+            // make the webhook fail and get redelivered.
+            log.warn("Could not explain an ignored {} on {}#{}", gesture, ctx.info().fullName(), ctx.issueRef(), e);
+        }
+    }
+
+    private String reasonFor(String gesture, Optional<Run> owner) {
+        if (owner.isEmpty()) {
+            return switch (gesture) {
+                case "assignment" -> "I can't take this issue: no workflow here claimed the assignment. " +
+                "That usually means this project or repository is outside every configured workflow's scope. " +
+                "Saying so rather than staying silent.";
+                case "plan approval" -> "I saw the approval, but no run exists for this issue — there is nothing " +
+                "to approve yet. Assign me first, and I'll plan it and ask for approval here.";
+                // An issue no run has ever owned is a human conversation.
+                default -> null;
+            };
+        }
+
+        Run run = owner.get();
+        if (run.status() == RunStatus.COMPLETED) {
+            return ("I didn't act on that %s: my run for this issue already completed, and delivered work is not " +
+                "redone on a stray event. To start a fresh round, remove me from the assignees and then assign " +
+                "me again.").formatted(gesture);
+        }
+        if (run.isTerminal()) {
+            return ("I didn't act on that %s: my run for this issue was %s. Assign me again to restart it from " +
+                "the beginning.").formatted(gesture, run.status().value());
+        }
+
+        String waits = store
+            .findPendingWaits(run.id())
+            .stream()
+            .map(wait -> wait.waitKey())
+            .collect(Collectors.joining(", "));
+        return ("I saw the %s, but I'm mid-way through this issue (state '%s') and that stage doesn't react to it. %s")
+            .formatted(
+                gesture,
+                run.state(),
+                waits.isEmpty()
+                    ? "The current stage finishes on its own; what happens next will be posted here."
+                    : "It is waiting on: " + waits + "."
+            );
+    }
+}

--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/WorkflowService.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/WorkflowService.java
@@ -25,15 +25,24 @@ public class WorkflowService {
     private final ContainerService containerService;
     private final RunStore runStore;
     private final RunEngine engine;
+    private final IgnoredEventExplainer explainer;
 
-    public WorkflowService(ContainerService containerService, RunStore runStore, RunEngine engine) {
+    public WorkflowService(
+        ContainerService containerService,
+        RunStore runStore,
+        RunEngine engine,
+        IgnoredEventExplainer explainer
+    ) {
         this.containerService = containerService;
         this.runStore = runStore;
         this.engine = engine;
+        this.explainer = explainer;
     }
 
     public void onEvent(WorkflowEvent event) {
-        engine.handle(event);
+        var outcomes = engine.handle(event);
+        // A human gesture nothing reacted to gets an explanation, not silence.
+        if (explainer != null) explainer.explainIfIgnored(event, outcomes);
     }
 
     /**

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/workflow/IgnoredEventExplainerTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/workflow/IgnoredEventExplainerTest.java
@@ -1,0 +1,146 @@
+package dev.smithyai.orchestrator.workflow;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.smithyai.orchestrator.model.IssueContext;
+import dev.smithyai.orchestrator.model.RepoInfo;
+import dev.smithyai.orchestrator.model.events.WorkflowEvent;
+import dev.smithyai.orchestrator.runtime.engine.RunEngine;
+import dev.smithyai.orchestrator.runtime.store.CorrelationKind;
+import dev.smithyai.orchestrator.runtime.store.Run;
+import dev.smithyai.orchestrator.runtime.store.RunRecorder;
+import dev.smithyai.orchestrator.runtime.store.RunStatus;
+import dev.smithyai.orchestrator.runtime.store.RunStore;
+import dev.smithyai.orchestrator.service.vcs.IssueTrackers;
+import dev.smithyai.orchestrator.testing.StubVcsClient;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+/**
+ * Every silence in here was once a real investigation: a person assigned,
+ * approved or asked, nothing reacted, and the reason had to be dug out of
+ * DEBUG logs hours later. The explainer posts that reason up front.
+ */
+class IgnoredEventExplainerTest {
+
+    private static final RepoInfo REPO = new RepoInfo(
+        "acme",
+        "platform",
+        "https://git.invalid/acme/platform",
+        "forgejo-main",
+        "forgejo"
+    );
+
+    @TempDir
+    Path tempDir;
+
+    private RunStore store;
+    private StubVcsClient tracker;
+    private IgnoredEventExplainer explainer;
+
+    @BeforeEach
+    void setUp() {
+        var dataSource = new DriverManagerDataSource("jdbc:sqlite:" + tempDir.resolve("runs.db") + "?foreign_keys=on");
+        dataSource.setDriverClassName("org.sqlite.JDBC");
+        Flyway.configure().dataSource(dataSource).locations("classpath:db/migration").load().migrate();
+        store = new RunStore(JdbcClient.create((DataSource) dataSource), new ObjectMapper());
+        tracker = new StubVcsClient();
+        explainer = new IgnoredEventExplainer(store, new IssueTrackers(Map.of("forgejo-main", tracker)));
+    }
+
+    private static WorkflowEvent comment(String body) {
+        return new WorkflowEvent.IssueComment(
+            new IssueContext(REPO, "ECD-9", "Add search", "body", "main", "smithy"),
+            body
+        );
+    }
+
+    private static WorkflowEvent assigned() {
+        return new WorkflowEvent.IssueAssigned(
+            new IssueContext(REPO, "ECD-9", "Add search", "body", "main", "coordinator"),
+            null
+        );
+    }
+
+    private Run ownedRun(RunStatus status, String state) {
+        var run = store.create("feature-coordinator", "1", state, null);
+        store.updateState(run.id(), state);
+        store.updateStatus(run.id(), status);
+        store.correlate(CorrelationKind.ISSUE, RunRecorder.issueRef("acme", "platform", "ECD-9"), run.id());
+        return run;
+    }
+
+    private static List<RunEngine.Outcome> nothingHandled() {
+        return List.of(new RunEngine.Outcome("feature-coordinator", null, null, null, false));
+    }
+
+    @Test
+    void aCommentOnACompletedRunExplainsHowToStartOver() {
+        ownedRun(RunStatus.COMPLETED, "done");
+
+        explainer.explainIfIgnored(comment("what is the status?"), nothingHandled());
+
+        assertEquals(1, tracker.issueComments.size(), tracker.issueComments.toString());
+        var reply = tracker.issueComments.getFirst();
+        assertTrue(reply.contains("completed"), reply);
+        assertTrue(reply.contains("assign me again"), reply);
+    }
+
+    @Test
+    void anAssignmentNoWorkflowClaimsIsExplained() {
+        explainer.explainIfIgnored(assigned(), List.of());
+
+        assertEquals(1, tracker.issueComments.size(), tracker.issueComments.toString());
+        assertTrue(tracker.issueComments.getFirst().contains("no workflow"), tracker.issueComments.getFirst());
+    }
+
+    @Test
+    void aGestureAtAStageWithNoEarForItNamesTheStage() {
+        ownedRun(RunStatus.WAITING, "executing");
+
+        explainer.explainIfIgnored(comment("please hurry"), nothingHandled());
+
+        assertEquals(1, tracker.issueComments.size(), tracker.issueComments.toString());
+        assertTrue(tracker.issueComments.getFirst().contains("state 'executing'"), tracker.issueComments.getFirst());
+    }
+
+    @Test
+    void aHandledEventNeedsNoExplanation() {
+        ownedRun(RunStatus.COMPLETED, "done");
+
+        explainer.explainIfIgnored(
+            comment("looks good"),
+            List.of(new RunEngine.Outcome("feature-coordinator", "run", "a", "b", true))
+        );
+
+        assertTrue(tracker.issueComments.isEmpty());
+    }
+
+    @Test
+    void aCommentOnAnIssueNoRunEverOwnedIsNoneOfTheBotsBusiness() {
+        explainer.explainIfIgnored(comment("hi team, thoughts?"), List.of());
+
+        assertTrue(tracker.issueComments.isEmpty(), "a human conversation is not answered");
+    }
+
+    @Test
+    void machineTrafficIsNeverExplained() {
+        ownedRun(RunStatus.COMPLETED, "done");
+
+        explainer.explainIfIgnored(
+            new WorkflowEvent.HumanPush(REPO, "some-branch"),
+            List.of()
+        );
+
+        assertTrue(tracker.issueComments.isEmpty(), "pushes go unhandled all the time, legitimately");
+    }
+}


### PR DESCRIPTION
## Why

A week of production incidents traces back to silently dropped events: "what is the status?" comments on a run stuck in `executing`, an assignment on a `completed` run that reopen refuses, a story raised in a project no workflow claims. Each silence was investigated by hand — logs, run store, container forensics — and each investigation ended in a one-line explanation that could have been posted in the first place.

## What changed

`WorkflowService.onEvent` now passes the engine's outcomes to a new `IgnoredEventExplainer`. When an **issue-scoped human gesture** (assignment, plan approval, comment) ends with nothing handled, the bot comments on the issue with the reason and the remedy:

- run **completed** → "delivered work is not redone on a stray event — remove me from the assignees and assign me again for a fresh round"
- run **cancelled/failed** → "assign me again to restart it"
- run **mid-stage** with no transition for the event → names the state and its pending waits ("it is waiting on: plan-approval")
- **no workflow claimed an assignment** → "this project/repository is outside every configured workflow's scope"
- plan-approval label with **no run** → "nothing to approve yet — assign me first"

Deliberate silences: machine traffic (pushes, CI, PR events) is never answered, and a comment on an issue no run has ever owned is a human conversation the bot stays out of. Failing to deliver the explanation is logged, never rethrown — a courtesy must not make the webhook fail and get redelivered.

## Tests

`IgnoredEventExplainerTest`: completed-run restart guidance, unclaimed assignment, mid-stage naming, handled events stay silent, unknown issues stay silent, machine traffic stays silent. Full `:backend:test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)