### PR TITLE
Explainer: stay silent on a redelivered assignment the run is already honouring

### DIFF
--- a/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/IgnoredEventExplainer.java
+++ b/orchestrator/backend/src/main/java/dev/smithyai/orchestrator/workflow/IgnoredEventExplainer.java
@@ -99,6 +99,14 @@ public class IgnoredEventExplainer {
                 "the beginning.").formatted(gesture, run.status().value());
         }
 
+        // An assignment landing on a run that is already working IS honoured —
+        // that run exists because of it. Trackers redeliver the assignment
+        // webhook when a long planning turn outlives their patience, and the
+        // redelivery queues up behind the run's lock; explaining it reads as
+        // the bot apologising for doing its job. Observed live: two of these
+        // half a second after the plan was posted.
+        if ("assignment".equals(gesture)) return null;
+
         String waits = store
             .findPendingWaits(run.id())
             .stream()

--- a/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/workflow/IgnoredEventExplainerTest.java
+++ b/orchestrator/backend/src/test/java/dev/smithyai/orchestrator/workflow/IgnoredEventExplainerTest.java
@@ -114,6 +114,17 @@ class IgnoredEventExplainerTest {
     }
 
     @Test
+    void aRedeliveredAssignmentOnAWorkingRunStaysSilent() {
+        // The run exists because of that assignment; a tracker redelivering the
+        // webhook mid-planning is not a person who needs an explanation.
+        ownedRun(RunStatus.RUNNING, "awaiting_approval");
+
+        explainer.explainIfIgnored(assigned(), nothingHandled());
+
+        assertTrue(tracker.issueComments.isEmpty(), "the acknowledgement already said 'on it'");
+    }
+
+    @Test
     void aHandledEventNeedsNoExplanation() {
         ownedRun(RunStatus.COMPLETED, "done");
 


### PR DESCRIPTION
## Why

First live outing of #50 produced two odd comments right after a plan was posted: *"I saw the assignment, but I'm mid-way through this issue (state 'awaiting_approval')…"* — twice, half a second apart. Cause: Jira redelivers the assignment webhook when the synchronous planning turn (~14 min) outlives its timeout; the redeliveries queue behind the run's lock and dispatch the moment planning ends; `awaiting_approval` has no ear for `issue.assigned`; the explainer explained.

Technically correct, humanly wrong: that run **exists because of that assignment** — the gesture was honoured, and the acknowledgement comment already said "on it". The bot was apologising for doing its job.

## What changed

An ignored `issue.assigned` on a **non-terminal** run stays silent. Terminal runs keep their explanation (completed → "re-assign for a fresh round", cancelled/failed → "assign again to restart"), where re-assigning genuinely needs guidance. Comments and plan approvals mid-stage keep theirs too.

New test: `aRedeliveredAssignmentOnAWorkingRunStaysSilent`. Full `:backend:test` green.

## Follow-ups noted, not included

- The dedup window (5 min) is shorter than tracker retry spacing on long turns — the structural fix is answering webhooks immediately and processing async, which is a larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)